### PR TITLE
fix: `nuxt-i18n-micro` integration

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -185,7 +185,7 @@ export default defineNuxtModule<ModuleOptions>({
       })
     }
 
-    if (!hasNuxtModule('@nuxtjs/i18n')) {
+    if (!hasNuxtModule('@nuxtjs/i18n') && !hasNuxtModule("nuxt-i18n-micro")) {
       addImports({
         from: resolve(`./runtime/nuxt/composables/polyfills`),
         name: 'useI18n',


### PR DESCRIPTION


### Description

Seo utils should not polyfill useI18n util if nuxt-i18n-micro is installed

### Additional context

Probably there is more work to be done to make i18n micro and nuxt seo fully compatible, this is just a quick fix because in a project we are dealing with useI18n mocks from nuxt seo overriding i18n composables from i18n-micro
