### PR TITLE
fix(useBreadcrumbItems): handle undefined route name

### DIFF
--- a/src/runtime/app/composables/useBreadcrumbItems.ts
+++ b/src/runtime/app/composables/useBreadcrumbItems.ts
@@ -159,10 +159,6 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
         const routeMeta = (route?.meta || {}) as RouteMeta & { title?: string, breadcrumbLabel: string }
         const routeName = route ? String(route.name?.split('___')) : (item.to === '/' ? 'index' : null)
         const fallbackLabel = titleCase(routeName === 'index' ? 'Home' : (item.to || '').split('/').pop() || '') // fallback to last path segment
-
-        if (!route?.name) {
-          console.warn(`[useBreadcrumbItems] Route name is undefined for path: ${item.to}`);
-        }
         
         // merge with the route meta
         if (routeMeta.breadcrumb) {

--- a/src/runtime/app/composables/useBreadcrumbItems.ts
+++ b/src/runtime/app/composables/useBreadcrumbItems.ts
@@ -157,8 +157,13 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
       .map((item) => {
         const route = router.resolve(item.to)?.matched?.[0] || router.currentRoute.value // fallback to current route
         const routeMeta = (route?.meta || {}) as RouteMeta & { title?: string, breadcrumbLabel: string }
-        const routeName = route ? String(route.name.split('___')) : (item.to === '/' ? 'index' : null)
+        const routeName = route ? String(route.name?.split('___')) : (item.to === '/' ? 'index' : null)
         const fallbackLabel = titleCase(routeName === 'index' ? 'Home' : (item.to || '').split('/').pop() || '') // fallback to last path segment
+
+        if (!route?.name) {
+          console.warn(`[useBreadcrumbItems] Route name is undefined for path: ${item.to}`);
+        }
+        
         // merge with the route meta
         if (routeMeta.breadcrumb) {
           item = {


### PR DESCRIPTION
### Description

In my app, I don’t have an `index.vue` file but a `[dashboard].vue`, which serves as the main entry point for the app. This was causing some issues with the `useBreadcrumbItems` composable. I realized the problem was due to my page missing a `name`.

Adding the following:

```javascript
definePageMeta({
  path: '/',
  name: 'index',
})
```

fixed the issue. However, I made this PR to improve the developer experience (DX). Previously, the page would crash with an error during the split. Now, the page works with a warning, and the item appears as `breadcrumb.items.undefined.label`. 
