### PR TITLE
feat!: shared `useBreadcrumbItems()` context

### DIFF
--- a/docs/content/3.api/4.breadcrumbs.md
+++ b/docs/content/3.api/4.breadcrumbs.md
@@ -122,6 +122,107 @@ export default {
 
 ::
 
+### Hierarchical Breadcrumbs
+
+It's common to want to have a breadcrumb in your top-level layout and then have this be completely dynamic
+for each page.
+
+While this will work, it gets more complicated once you need to start overriding the breadcrumb list for data that's only available
+from a fetch.
+
+Consider a blog example where we want to show something like:
+
+- Blog (`/blog`) -> Dynamic Category (`/blog/dynamic-category`) -> Post title (`/blog/dynamic-category/post-title`)
+
+You would be tempted to insert the breadcrumb in the blog layout. However, this has issues.
+
+```vue twoslash [blog.vue]
+<script lang="ts" setup>
+import { useBreadcrumbItems } from '#imports'
+const items = useBreadcrumbItems({
+  rootNode: '/blog',
+  overrides: [
+    { label: 'My Cool Blog', }, // Home
+    // ❌ We're missing data to render the post title and category
+  ]
+})
+</script>
+
+<template>
+  <div>
+    <Breadcrumb :items="useBreadcrumbItems()" />
+  </div>
+</template>
+```
+
+Instead, we need to render the breadcrumb list as late as possible in the render tree. This means we need to
+insert the breadcrumb in the page component.
+
+However, this means we may need to do prop drilling to get the data to the breadcrumb. Instead, we can use the shared
+breadcrumb context that's based on the `id`.
+
+::code-group
+
+```vue [app.vue]
+<script lang="ts" setup>
+// setup root breadcrumb config
+useBreadcrumbItems({
+  overrides: [
+    { label: 'My Cool Site', },
+  ]
+})
+</script>
+```
+
+```vue twoslash [layouts/blog.vue]
+<script lang="ts" setup>
+// example path /blog/<category>/<post>
+const category = await useFetch<{ slug: string }>('/api/category', { params: { category: useRoute().params.category } })
+
+// setup breadcrumb root config
+useBreadcrumbItems({
+  overrides: [
+    undefined,
+    { label: 'Category', to: `/blog/${category.value.slug}` },
+  ]
+})
+</script>
+
+<template>
+<div>
+  <!-- ❌  don't render breadcrumbs here -->  
+</div>
+</template>
+```
+
+```vue [blog/[category]/[...post].vue]
+<script lang="ts" setup>
+definePageMeta({
+  layout: 'blog',
+})
+// example
+const post = await useFetch('/api/post', { params: { post: useRoute().params.post } })
+
+const items = useBreadcrumbItems({
+  overrides: [
+    undefined, // avoid overriding the root
+    undefined,
+    { label: 'Post Title', to: `/blog/${useRoute().params.category}/${post.value.slug}` }
+  ]
+})
+</script>
+
+<template>
+<div>
+  <!-- ✅ render breadcrumbs here -->
+</div>
+</template>
+```
+
+::
+
+This may change your design a bit, but it's the only way to reliable handle this without a hydration issue.
+
 ## Props
 
 ### `path`
@@ -179,3 +280,12 @@ An array of items to append to the generated breadcrumbs.
 - Default: `[]`{lang="ts"}
 
 An array of items to prepend to the generated breadcrumbs.
+
+### `rootNode`
+
+- Type: `string`{lang="ts"}
+- Default: `undefined`{lang="ts"}
+
+The root node to use for the breadcrumb. This is useful for when you want to generate a breadcrumb for a specific route.
+
+The default will either use `/` or the i18n prefixed alternative.

--- a/docs/content/3.api/4.breadcrumbs.md
+++ b/docs/content/3.api/4.breadcrumbs.md
@@ -189,9 +189,9 @@ useBreadcrumbItems({
 </script>
 
 <template>
-<div>
-  <!-- ❌  don't render breadcrumbs here -->  
-</div>
+  <div>
+  <!-- ❌  don't render breadcrumbs here -->
+  </div>
 </template>
 ```
 
@@ -213,9 +213,9 @@ const items = useBreadcrumbItems({
 </script>
 
 <template>
-<div>
+  <div>
   <!-- ✅ render breadcrumbs here -->
-</div>
+  </div>
 </template>
 ```
 

--- a/docs/content/4.releases/2.v7.md
+++ b/docs/content/4.releases/2.v7.md
@@ -12,7 +12,7 @@ support for automatic icon creation.
 
 ### Shared Breadcrumb Context
 
-If you were previously rendering multiple `<Breadcrumb>` components on the same page without specifying an `id`,
+If you were previously generating multiple breadcrumb lists on the same page without specifying an `id`,
 you will now run into issues with context being shared between the components.
 
 This is intentional as previously you would be rendering invalid Schema.org markup.

--- a/docs/content/4.releases/2.v7.md
+++ b/docs/content/4.releases/2.v7.md
@@ -1,0 +1,26 @@
+---
+title: v6.0.0
+description: Release notes for v6.0.0 of Nuxt SEO Utils.
+---
+
+## Introduction
+
+The v7 major includes improved defaults for safer canonical URLs, improved breadcrumb usage and 
+support for automatic icon creation.
+
+## :icon{name="i-noto-warning"} Breaking Changes
+
+### Shared Breadcrumb Context
+
+If you were previously rendering multiple `<Breadcrumb>` components on the same page without specifying an `id`,
+you will now run into issues with context being shared between the components.
+
+This is intentional as previously you would be rendering invalid Schema.org markup.
+
+To fix this you should specify an `id` which will have shared context.
+
+```ts
+useBreadcrumbItems({
+  id: 'my-breadcrumb',
+})
+```

--- a/docs/content/4.releases/2.v7.md
+++ b/docs/content/4.releases/2.v7.md
@@ -5,7 +5,7 @@ description: Release notes for v6.0.0 of Nuxt SEO Utils.
 
 ## Introduction
 
-The v7 major includes improved defaults for safer canonical URLs, improved breadcrumb usage and 
+The v7 major includes improved defaults for safer canonical URLs, improved breadcrumb usage and
 support for automatic icon creation.
 
 ## :icon{name="i-noto-warning"} Breaking Changes

--- a/docs/content/4.releases/3.v6.md
+++ b/docs/content/4.releases/3.v6.md
@@ -5,9 +5,9 @@ description: Release notes for v6.0.0 of Nuxt SEO Utils.
 
 ## Introduction
 
-The v5 major of Nuxt SEO Utils is a simple release to remove deprecations and add support for the [Nuxt SEO v2 stable](https://nuxtseo.com/announcement).
+The v6 major of Nuxt SEO Utils is a simple release to remove deprecations and add support for the [Nuxt SEO v2 stable](https://nuxtseo.com/announcement).
 
-## :icon{name="i-noto-warning"} Breaking Features
+## :icon{name="i-noto-warning"} Breaking Changes
 
 ### Site Config v3
 

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { updateSiteConfig, useI18n, useRoute, useSiteConfig } from '#imports'
+import { useBreadcrumbItems } from '#seo-utils/app/composables/useBreadcrumbItems'
 
 const i18n = useI18n()
 
@@ -22,6 +23,14 @@ if (route.query.name) {
   })
 }
 
+useBreadcrumbItems({
+  overrides: [
+    { label: 'My Cool Site' },
+  ],
+  append: [
+    { label: 'this is appended' },
+  ],
+})
 const siteConfig = useSiteConfig()
 </script>
 

--- a/playground/pages/docs/[...slug].vue
+++ b/playground/pages/docs/[...slug].vue
@@ -1,14 +1,18 @@
 <script setup lang="ts">
-import { useBreadcrumbItems } from '#seo-utils/app/composables/useBreadcrumbItems'
-
-const breacrumb = useBreadcrumbItems()
+const items = useBreadcrumbItems({
+  overrides: [
+    undefined,
+    { label: 'Documentation' },
+    { label: 'Intro - yo' },
+  ],
+})
 </script>
 
 <template>
   <div>
-    catch-all
+    docs slug catch-all
     <nav>
-      {{ breacrumb.map(item => item.label).join(' > ') }}
+      {{ items.map(item => item.label).join(' > ') }}
     </nav>
   </div>
 </template>

--- a/src/runtime/unhead-v2/app/composables/useBreadcrumbItems.ts
+++ b/src/runtime/unhead-v2/app/composables/useBreadcrumbItems.ts
@@ -1,5 +1,5 @@
 import type { NuxtLinkProps } from 'nuxt/app'
-import type { MaybeRefOrGetter } from 'vue'
+import type { MaybeRefOrGetter, Ref } from 'vue'
 import type { RouteMeta } from 'vue-router'
 import {
   defineBreadcrumb,
@@ -12,7 +12,7 @@ import { defu } from 'defu'
 import { fixSlashes } from 'nuxt-site-config/urls'
 import { useRouter } from 'nuxt/app'
 import { withoutTrailingSlash } from 'ufo'
-import { computed, toValue } from 'vue'
+import { computed, inject, onUnmounted, provide, ref, toRaw, toValue } from 'vue'
 import { pathBreadcrumbSegments } from '../../shared/breadcrumbs'
 
 interface NuxtUIBreadcrumbItem extends NuxtLinkProps {
@@ -77,6 +77,12 @@ export interface BreadcrumbProps {
    * Should the root breadcrumb be shown.
    */
   hideRoot?: MaybeRefOrGetter<boolean>
+  /**
+   * The root segment of the breadcrumb list.
+   *
+   * By default, this will be `/`, unless you're using Nuxt I18n with a prefix strategy.
+   */
+  rootSegment?: string
 }
 
 export interface BreadcrumbItemProps extends NuxtUIBreadcrumbItem {
@@ -110,6 +116,8 @@ function titleCase(s: string) {
     .replace(/\w\S*/g, w => w.charAt(0).toUpperCase() + w.substr(1).toLowerCase())
 }
 
+const BreadcrumbCtx = Symbol('BreadcrumbCtx')
+
 /**
  * Generate an automatic breadcrumb list that helps users to navigate between pages.
  *
@@ -119,7 +127,29 @@ function titleCase(s: string) {
  * @see https://github.com/harlan-zw/nuxt-seo/blob/main/src/runtime/nuxt/composables/useBreadcrumbItems.ts
  * @docs https://nuxtseo.com/nuxt-seo/api/breadcrumbs
  */
-export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
+export function useBreadcrumbItems(_options: BreadcrumbProps = {}) {
+  let isCreatingState = false
+  let stateRef: Ref<Record<string, BreadcrumbProps[]>> | null = inject(BreadcrumbCtx, null)
+  if (!stateRef) {
+    stateRef = ref({})
+    provide(BreadcrumbCtx, stateRef)
+    isCreatingState = false
+  }
+  const id = 'breadcrumb'
+  const state = stateRef.value
+  if (!state[id]) {
+    state[id] = []
+  }
+  const idx = state[id].push(_options) - 1
+  stateRef.value = state
+  onUnmounted(() => {
+    stateRef.value = Object.fromEntries(Object.entries(stateRef.value).map(([k, v]) => {
+      if (k === id) {
+        return v.filter((_, i) => i !== idx)
+      }
+      return v
+    }))
+  })
   const router = useRouter()
   const i18n = useI18n()
   const siteResolver = createSitePathResolver({
@@ -128,36 +158,56 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
   })
   const siteConfig = useSiteConfig()
   const items = computed(() => {
-    let rootNode = '/'
+    const optionStack = stateRef.value?.[id]
+    const flatOptions = toRaw([...optionStack]).reduce((acc, cur) => {
+      acc.rootSegment = acc.rootSegment || cur.rootSegment
+      acc.path = acc.path || cur.path
+      return acc
+    }, {})
+    let rootNode = flatOptions.rootSegment || '/'
     if (i18n) {
       if (i18n.strategy === 'prefix' || (i18n.strategy !== 'no_prefix' && toValue(i18n.defaultLocale) !== toValue(i18n.locale)))
-        rootNode = `/${toValue(i18n.locale)}`
+        rootNode = `${rootNode}${toValue(i18n.locale)}`
     }
-    const current = withoutQuery(withoutTrailingSlash(toValue(options.path || router.currentRoute.value?.path) || rootNode))
+    const current = withoutQuery(withoutTrailingSlash(toValue(flatOptions.path || router.currentRoute.value?.path) || rootNode))
     // apply overrides
-    const overrides = toValue(options.overrides) || []
+    const allOverrides = toRaw([...optionStack])?.map(opts => toValue(opts.overrides)).filter(Boolean)
+    const flatOverrides = allOverrides?.reduce((acc: (BreadcrumbItemProps | false | undefined)[], i) => {
+      // merge them based on index
+      if (i) {
+        i.forEach((item, index) => {
+          if (item !== undefined) {
+            acc[index] = item
+          }
+        })
+      }
+      return acc
+    }, []) || {}
     const segments = pathBreadcrumbSegments(current, rootNode)
       .map((path, index) => {
         let item = <BreadcrumbItemProps> {
           to: path,
         }
-        if (typeof overrides[index] !== 'undefined') {
-          if (overrides[index] === false)
+        if (typeof flatOverrides[index] !== 'undefined') {
+          if (flatOverrides[index] === false)
             return false
-          item = defu(overrides[index] as any as BreadcrumbItemProps, item)
+          item = defu(flatOverrides[index] as any as BreadcrumbItemProps, item)
         }
         return item
       })
+
+    const allPrepends = toRaw([...optionStack]).flatMap(opts => toValue(opts.prepend)).filter(Boolean) as any as BreadcrumbItemProps[]
+    const allAppends = toRaw([...optionStack]).flatMap(opts => toValue(opts.append)).filter(Boolean) as any as BreadcrumbItemProps[]
     // apply prepends and appends
-    if (options.prepend)
-      segments.unshift(...toValue(options.prepend))
-    if (options.append)
-      segments.push(...toValue(options.append))
+    if (allPrepends.length)
+      segments.unshift(...allPrepends)
+    if (allAppends.length)
+      segments.push(...allAppends)
     return (segments.filter(Boolean) as BreadcrumbItemProps[])
       .map((item) => {
         let fallbackLabel = titleCase(String((item.to || '').split('/').pop()))
         let fallbackAriaLabel = ''
-        const route = router.resolve(item.to as string)?.matched?.[0]
+        const route = item.to ? router.resolve(item.to as string)?.matched?.[0] : null
         if (route) {
           const routeMeta = (route?.meta || {}) as RouteMeta & { title?: string, breadcrumbLabel: string, breadcrumbTitle: string }
           // merge with the route meta
@@ -172,7 +222,7 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
             fallbackLabel = 'Home'
           }
           fallbackLabel = routeMeta.breadcrumbLabel || routeMeta.breadcrumbTitle || routeMeta.title || fallbackLabel
-          fallbackLabel = i18n.t(`breadcrumb.items.${routeName}.label`, fallbackLabel, { missingWarn: true })
+          fallbackLabel = i18n.t(`breadcrumb.items.${routeName}.label`, fallbackLabel, { missingWarn: false })
           fallbackAriaLabel = i18n.t(`breadcrumb.items.${routeName}.ariaLabel`, fallbackAriaLabel, { missingWarn: false })
         }
 
@@ -181,14 +231,14 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
         item.ariaLabel = item.ariaLabel || fallbackAriaLabel || item.label
         // mark the current based on the options
         item.current = item.current || item.to === current
-        if (toValue(options.hideCurrent) && item.current)
+        if (toValue(flatOptions.hideCurrent) && item.current)
           return false
         return item
       })
       .map((m) => {
         if (m && m.to) {
           m.to = fixSlashes(siteConfig.trailingSlash, m.to)
-          if (m.to === rootNode && toValue(options.hideRoot))
+          if (m.to === rootNode && toValue(flatOptions.hideRoot))
             return false
         }
         return m
@@ -196,12 +246,12 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
       .filter(Boolean) as BreadcrumbItemProps[]
   })
 
-  const schemaOrgEnabled = typeof options.schemaOrg === 'undefined' ? true : options.schemaOrg
+  const schemaOrgEnabled = typeof _options.schemaOrg === 'undefined' ? true : _options.schemaOrg
   // TODO can probably drop this schemaOrgEnabled flag as we mock the function
-  if ((import.meta.dev || import.meta.server || import.meta.env?.NODE_ENV === 'test') && schemaOrgEnabled) {
+  if (isCreatingState && (import.meta.dev || import.meta.server || import.meta.env?.NODE_ENV === 'test') && schemaOrgEnabled) {
     useSchemaOrg([
       defineBreadcrumb({
-        id: `#${options.id || 'breadcrumb'}`,
+        id: `#${_options.id || 'breadcrumb'}`,
         itemListElement: computed(() => items.value.map(item => ({
           name: item.label || item.ariaLabel,
           item: item.to ? siteResolver(item.to) : undefined,


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Allows you to specify breadcrumb config across components.

```vue
<script lang="ts" setup>
// app.vue
useBreadcrumbItems({
  overides: [
    { label: '!Home!' },
  ]
})
</script>
```

```vue
<script lang="ts" setup>
// pages/example.vue
const items = useBreadcrumbItems()
</script>
<template>
<div>{{ items }}</div>
</template>
```

Where this would render:

- `!Home!` -> `Example`

:warning: Breaking Changes

If you were previously generating multiple breadcrumb lists on the same page without specifying an `id`,
you will now run into issues with context being shared between the components.

This is intentional as previously you would be rendering invalid Schema.org markup.

To fix this you should specify an `id` which will have shared context.

```ts
useBreadcrumbItems({
  id: 'my-breadcrumb',
})
```

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

https://github.com/harlan-zw/nuxt-seo-utils/issues/31
https://github.com/harlan-zw/nuxt-seo/issues/395

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
