### PR TITLE
fix(useBreadcrumbItems): hydration mismatch for breadcrumb items

### DIFF
--- a/src/runtime/app/composables/useBreadcrumbItems.ts
+++ b/src/runtime/app/composables/useBreadcrumbItems.ts
@@ -139,6 +139,7 @@ const BreadcrumbCtx = Symbol('BreadcrumbCtx')
  * @docs https://nuxtseo.com/nuxt-seo/api/breadcrumbs
  */
 export function useBreadcrumbItems(_options: BreadcrumbProps = {}) {
+  const nuxtApp = useNuxtApp()
   const vm = getCurrentInstance()
   const id = `${vm?.uid || 0}:${_options.id || 'breadcrumb'}`
   const parentChain: number[] = []
@@ -147,7 +148,7 @@ export function useBreadcrumbItems(_options: BreadcrumbProps = {}) {
     parentChain.push(parent.uid)
     parent = parent.parent
   }
-  const pauseUpdates = ref(import.meta.client)
+  const pauseUpdates = ref(import.meta.client && !nuxtApp.isHydrating)
   let stateRef: Ref<Record<string, BreadcrumbProps>> | null = null
   if (vm) {
     stateRef = inject(BreadcrumbCtx, null)
@@ -164,7 +165,6 @@ export function useBreadcrumbItems(_options: BreadcrumbProps = {}) {
       stateRef!.value = state
     })
     if (import.meta.client) {
-      const nuxtApp = useNuxtApp()
       const _: any[] = []
       // pause dom updates until page is ready and between page transitions
       _.push(nuxtApp.hooks.hook('page:start', () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #56 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The change fixes hydration mismatch by setting initial value of `pauseUpdates` ref to false if the app is hydrating.
