### PR TITLE
fix(useBreadcrumbItems): ensure overrides take precedence over route.meta.breadcrumb

### DIFF
--- a/src/runtime/app/composables/useBreadcrumbItems.ts
+++ b/src/runtime/app/composables/useBreadcrumbItems.ts
@@ -281,10 +281,7 @@ export function useBreadcrumbItems(_options: BreadcrumbProps = {}) {
           const routeMeta = (route?.meta || {}) as RouteMeta & { title?: string, breadcrumbLabel: string, breadcrumbTitle: string }
           // merge with the route meta
           if (routeMeta.breadcrumb) {
-            item = {
-              ...item,
-              ...routeMeta.breadcrumb,
-            }
+            item = defu(item, routeMeta.breadcrumb);
           }
           const routeName = String(route.name).split('___')?.[0]
           if (routeName === 'index') {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When you use definePageMeta with a `breadcrumb: { label: 'Label' }`, the overrides option in `useBreadcrumbItems({ overrides: [...] })` no longer works. The breadcrumb label defined in the page meta always takes precedence and cannot be overridden from a component or page.