### PR TITLE
fix: support unhead v3 alongside v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
       "unhead",
       "@unhead/vue",
       "@unhead/vue/plugins",
-      "@unhead/vue/utils"
+      "@unhead/vue/utils",
+      "@unhead/vue/vite",
+      "@unhead/addons/vite"
     ]
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,10 +34,10 @@ catalogs:
       specifier: ^25.6.0
       version: 25.6.0
     '@unhead/addons':
-      specifier: ^2.1.13
+      specifier: ^2.1.13 || ^3.0.0
       version: 2.1.13
     '@unhead/vue':
-      specifier: ^2.1.13
+      specifier: ^2.1.13 || ^3.0.0
       version: 2.1.13
     '@vue/test-utils':
       specifier: ^2.4.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,8 +17,8 @@ catalog:
   '@nuxt/ui': ^4.6.1
   '@nuxtjs/i18n': ^10.2.4
   '@types/node': ^25.6.0
-  '@unhead/addons': ^2.1.13
-  '@unhead/vue': ^2.1.13
+  '@unhead/addons': ^2.1.13 || ^3.0.0
+  '@unhead/vue': ^2.1.13 || ^3.0.0
   '@vue/test-utils': ^2.4.6
   bumpp: ^11.0.1
   case-police: ^2.2.0

--- a/src/module.ts
+++ b/src/module.ts
@@ -11,7 +11,6 @@ import {
   hasNuxtModule,
   useLogger,
 } from '@nuxt/kit'
-import UnheadVite from '@unhead/addons/vite'
 import { defu } from 'defu'
 import { installNuxtSiteConfig } from 'nuxt-site-config/kit'
 import { relative } from 'pathe'
@@ -383,9 +382,26 @@ export {}
     })
 
     const appRuntimeDir = resolve(runtimeDir, './app')
-    // remove useServerHead in client build
+    // remove useServerHead in client build + transform useSeoMeta -> useHead
     if (config.treeShakeUseSeoMeta) {
-      addVitePlugin(UnheadVite(), {
+      // Pick the right Vite plugin entry: v3 ships it inside @unhead/vue itself
+      // (named `Unhead` export), v2 only exposes it via @unhead/addons/vite as
+      // a default export. Detect installed major and defer the import so v3
+      // users don't need @unhead/addons in their tree.
+      const unheadPkg = await readPackageJSON('@unhead/vue', { from: nuxt.options.rootDir }).catch(() => null)
+      const unheadMajor = Number.parseInt((unheadPkg?.version || '2').split('.')[0]!, 10)
+      addVitePlugin(async () => {
+        if (unheadMajor >= 3) {
+          // String-variable import keeps TS from resolving the v3-only subpath
+          // when consumers/devs are on v2.
+          const v3Vite = '@unhead/vue/vite'
+          const { Unhead } = await import(v3Vite) as { Unhead: () => any }
+          return Unhead()
+        }
+        const v2Vite = '@unhead/addons/vite'
+        const { default: UnheadVite } = await import(v2Vite) as { default: () => any }
+        return UnheadVite()
+      }, {
         prepend: true,
       })
     }

--- a/src/runtime/app/logic/applyDefaults.ts
+++ b/src/runtime/app/logic/applyDefaults.ts
@@ -3,7 +3,7 @@ import type { QueryObject } from 'ufo'
 
 import { useSiteConfig } from '#site-config/app/composables/useSiteConfig'
 import { createSitePathResolver } from '#site-config/app/composables/utils'
-import { injectHead, useHead, useSeoMeta, useServerSeoMeta } from '@unhead/vue'
+import { injectHead, useHead, useSeoMeta } from '@unhead/vue'
 import { TemplateParamsPlugin } from '@unhead/vue/plugins'
 import { useError, useRoute, useRuntimeConfig } from 'nuxt/app'
 import { stringifyQuery } from 'ufo'
@@ -99,12 +99,11 @@ export function applyDefaults(): void {
     },
     ogSiteName: siteConfig.name,
   }
-  // Set a default description via useServerSeoMeta so SSR-only page-level
-  // descriptions are not overridden during hydration by client-side defaults
-  // registered with useSeoMeta. The siteConfig plugin also registers a
-  // low-priority client-side fallback with tagPriority: 'low'.
-  if (siteConfig.description)
-    useServerSeoMeta({ description: siteConfig.description }, minimalPriority)
+  // SSR-only default description so page-level descriptions are not overridden
+  // during hydration by client-side defaults registered with useSeoMeta. The
+  // siteConfig plugin also registers a low-priority client-side fallback.
+  if (import.meta.server && siteConfig.description)
+    useSeoMeta({ description: siteConfig.description }, minimalPriority)
   if (siteConfig.twitter) {
     // id must have the @ in it
     const id = siteConfig.twitter.startsWith('@')

--- a/src/runtime/app/plugins/inferSeoMetaPlugin.ts
+++ b/src/runtime/app/plugins/inferSeoMetaPlugin.ts
@@ -1,7 +1,6 @@
-import { InferSeoMetaPlugin } from '@unhead/addons'
 import { injectHead } from '@unhead/vue'
+import { InferSeoMetaPlugin, TemplateParamsPlugin } from '@unhead/vue/plugins'
 import { defineNuxtPlugin } from 'nuxt/app'
-import { TemplateParamsPlugin } from 'unhead/plugins'
 
 export default defineNuxtPlugin(() => {
   const head = injectHead()

--- a/test/fixtures/basic/.nuxtrc
+++ b/test/fixtures/basic/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.0.0"
+setups.@nuxt/test-utils="4.0.2"


### PR DESCRIPTION
### 🔗 Linked issue

_No linked issue._

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Widens the `@unhead/vue` / `@unhead/addons` catalog ranges to `^2.1.13 || ^3.0.0` and resolves the Vite treeshake plugin dynamically so the module works on both majors: v3 exposes it as the named `Unhead` export from `@unhead/vue/vite`, v2 only via the default export of `@unhead/addons/vite`. Detection uses `readPackageJSON` on the consumer's installed `@unhead/vue` version.

Also drops the direct `@unhead/addons` import from `inferSeoMetaPlugin` (both majors re-export `InferSeoMetaPlugin` from `@unhead/vue/plugins`) and replaces the deprecated `useServerSeoMeta` with a `import.meta.server`-guarded `useSeoMeta` for the site description default.