### PR TITLE
fix: respect existing title separator

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -308,6 +308,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
     nuxt.options.experimental.headNext = true
 
+    const headTemplateParams = (nuxt.options.app.head as Record<string, any> | undefined)?.templateParams as Record<string, any> | undefined
     // add redirect middleware
     if (!nuxt.options.dev && config.redirectToCanonicalSiteUrl) {
       addServerHandler({
@@ -329,6 +330,8 @@ export default defineNuxtModule<ModuleOptions>({
       ],
       canonicalLowercase: config.canonicalLowercase,
       tagPriority: config.tagPriority,
+      separator: headTemplateParams?.separator,
+      titleSeparator: headTemplateParams?.titleSeparator,
     })
 
     if (config.extendNuxtConfigAppHeadSeoMeta)

--- a/src/runtime/app/logic/applyDefaults.ts
+++ b/src/runtime/app/logic/applyDefaults.ts
@@ -26,10 +26,18 @@ export function applyDefaults(): void {
   const head = injectHead()
   head.use(TemplateParamsPlugin)
   // get the head instance
-  const { canonicalQueryWhitelist, canonicalLowercase, tagPriority } = useRuntimeConfig().public['seo-utils'] as { canonicalQueryWhitelist: string[], canonicalLowercase: boolean, tagPriority: number | undefined }
+  const { canonicalQueryWhitelist, canonicalLowercase, tagPriority, separator, titleSeparator } = useRuntimeConfig().public['seo-utils'] as {
+    canonicalQueryWhitelist: string[]
+    canonicalLowercase: boolean
+    tagPriority: number | undefined
+    separator?: string
+    titleSeparator?: string
+  }
   const route = useRoute()
   const resolveUrl = createSitePathResolver({ withBase: true, absolute: true })
   const err = useError()
+  const resolveSeparator = () => toValue(siteConfig.separator) || separator || toValue(siteConfig.titleSeparator) || titleSeparator
+  const resolveTitleSeparator = () => toValue(siteConfig.titleSeparator) || titleSeparator || toValue(siteConfig.separator) || separator
   const canonicalUrl = computed<Link | false>(() => {
     if (err.value) {
       return false
@@ -72,6 +80,8 @@ export function applyDefaults(): void {
     templateParams: {
       site: () => siteConfig,
       siteName: () => siteConfig.name,
+      separator: resolveSeparator,
+      titleSeparator: resolveTitleSeparator,
     },
     titleTemplate: () => err.value ? '%s' : '%s %separator %siteName',
     link: [() => canonicalUrl.value],

--- a/src/runtime/app/plugins/siteConfig.ts
+++ b/src/runtime/app/plugins/siteConfig.ts
@@ -9,8 +9,14 @@ export default defineNuxtPlugin(() => {
   if (!head)
     return
 
-  const { tagPriority } = useRuntimeConfig().public['seo-utils'] as { tagPriority: number | 'critical' | 'high' | 'low' | `before:${string}` | `after:${string}` | undefined }
+  const { tagPriority, separator, titleSeparator } = useRuntimeConfig().public['seo-utils'] as {
+    tagPriority: number | 'critical' | 'high' | 'low' | `before:${string}` | `after:${string}` | undefined
+    separator?: string
+    titleSeparator?: string
+  }
   const siteConfig = useSiteConfig()
+  const resolvedSeparator = siteConfig.separator || separator || siteConfig.titleSeparator || titleSeparator
+  const resolvedTitleSeparator = siteConfig.titleSeparator || titleSeparator || siteConfig.separator || separator
   const input: Head = {
     meta: [],
     templateParams: {
@@ -20,10 +26,10 @@ export default defineNuxtPlugin(() => {
       siteName: siteConfig.name,
     },
   }
-  if (siteConfig.separator)
-    input.templateParams!.separator = siteConfig.separator
-  if (siteConfig.titleSeparator)
-    input.templateParams!.titleSeparator = siteConfig.titleSeparator
+  if (resolvedSeparator)
+    input.templateParams!.separator = resolvedSeparator
+  if (resolvedTitleSeparator)
+    input.templateParams!.titleSeparator = resolvedTitleSeparator
   if (siteConfig.description) {
     input.templateParams!.siteDescription = siteConfig.description
     // we can setup a meta description

--- a/test/unit/separatorFallback.test.ts
+++ b/test/unit/separatorFallback.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+const state = vi.hoisted(() => ({
+  runtimeConfig: {
+    public: {
+      'seo-utils': {
+        tagPriority: 'low' as const,
+        separator: '·',
+        titleSeparator: undefined as string | undefined,
+        canonicalQueryWhitelist: [] as string[],
+        canonicalLowercase: false,
+      },
+    },
+  },
+  siteConfig: {
+    name: 'My Site',
+    url: 'https://example.com',
+    defaultLocale: 'en',
+  } as Record<string, unknown>,
+  pushed: [] as Record<string, unknown>[],
+  headed: [] as Record<string, unknown>[],
+  seoMeta: [] as Record<string, unknown>[],
+  headUse: vi.fn(),
+}))
+
+vi.mock('nuxt/app', () => ({
+  defineNuxtPlugin: (plugin: unknown) => plugin,
+  useRuntimeConfig: () => state.runtimeConfig,
+  useRoute: () => ({
+    path: '/',
+    query: {},
+  }),
+  useError: () => ref(null),
+}))
+
+vi.mock('#site-config/app/composables/useSiteConfig', () => ({
+  useSiteConfig: () => state.siteConfig,
+}))
+
+vi.mock('#site-config/app/composables/utils', () => ({
+  createSitePathResolver: () => (path: string) => ({
+    value: `https://example.com${path}`,
+  }),
+}))
+
+vi.mock('@unhead/vue/plugins', () => ({
+  TemplateParamsPlugin: Symbol.for('template-params-plugin'),
+}))
+
+vi.mock('@unhead/vue', () => ({
+  injectHead: () => ({
+    push: (input: Record<string, unknown>) => state.pushed.push(input),
+    use: state.headUse,
+  }),
+  useHead: (input: Record<string, unknown>) => state.headed.push(input),
+  useSeoMeta: (input: Record<string, unknown>) => state.seoMeta.push(input),
+}))
+
+const siteConfigPluginModule = import('../../src/runtime/app/plugins/siteConfig')
+const applyDefaultsModule = import('../../src/runtime/app/logic/applyDefaults')
+
+beforeEach(() => {
+  state.runtimeConfig.public['seo-utils'] = {
+    tagPriority: 'low',
+    separator: '·',
+    titleSeparator: undefined,
+    canonicalQueryWhitelist: [],
+    canonicalLowercase: false,
+  }
+  state.siteConfig = {
+    name: 'My Site',
+    url: 'https://example.com',
+    defaultLocale: 'en',
+  }
+  state.pushed = []
+  state.headed = []
+  state.seoMeta = []
+  state.headUse.mockReset()
+})
+
+describe('separator fallback', () => {
+  it('siteConfig plugin preserves existing runtime separator fallback', async () => {
+    const plugin = (await siteConfigPluginModule).default as () => void
+    plugin()
+    const input = state.pushed[0] as { templateParams: { separator: string, titleSeparator: string } }
+
+    expect(input.templateParams.separator).toBe('·')
+    expect(input.templateParams.titleSeparator).toBe('·')
+  })
+
+  it('siteConfig plugin prefers explicit site config separator', async () => {
+    state.siteConfig.separator = '/'
+
+    const plugin = (await siteConfigPluginModule).default as () => void
+    plugin()
+    const input = state.pushed[0] as { templateParams: { separator: string, titleSeparator: string } }
+
+    expect(input.templateParams.separator).toBe('/')
+    expect(input.templateParams.titleSeparator).toBe('/')
+  })
+
+  it('applyDefaults injects separator template params for client title recomputes', async () => {
+    const { applyDefaults } = await applyDefaultsModule
+    applyDefaults()
+    const input = state.headed[0] as {
+      templateParams: {
+        separator: () => string
+        titleSeparator: () => string
+      }
+      titleTemplate: () => string
+    }
+
+    expect(state.headUse).toHaveBeenCalledWith(Symbol.for('template-params-plugin'))
+    expect(input.templateParams.separator()).toBe('·')
+    expect(input.templateParams.titleSeparator()).toBe('·')
+    expect(input.titleTemplate()).toBe('%s %separator %siteName')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

SSR was rendering the configured title separator correctly, but the client-side head recompute could fall back to Unhead's default `|` because `nuxt-seo-utils` only sourced `%separator` from site config. This change carries existing `app.head.templateParams.separator` and `titleSeparator` values into runtime defaults, prefers explicit site config when present, and adds regression coverage for the hydration path.

### ✅ Verification

- `pnpm lint`
- `pnpm build`
- `pnpm typecheck` currently fails on `main` with pre-existing baseline errors in `src/util.ts` and existing Unhead typing issues, and fails the same way on this branch.