### PR TITLE
fix: preserve descendant combinator in selector functions during CSS minify

### DIFF
--- a/src/runtime/shared/minify.ts
+++ b/src/runtime/shared/minify.ts
@@ -70,7 +70,11 @@ export function minifyJS(code: string): string {
 export function minifyCSS(code: string): string {
   let result = ''
   let i = 0
-  let parenDepth = 0
+  // Stack of paren contexts: true = selector-function paren (:is/:where/:not/:has),
+  // false = value paren (calc/min/max/clamp/var/rgb…). Whitespace rules differ:
+  // value parens may strip spaces around * and /, selector parens must not (the
+  // space before * is the descendant combinator, e.g. Tailwind v4 group-* variants).
+  const parenStack: boolean[] = []
   const len = code.length
 
   while (i < len) {
@@ -95,14 +99,14 @@ export function minifyCSS(code: string): string {
         i++
       i += 2
     }
-    // track paren depth for calc()/min()/max()/clamp()/var()
+    // track paren context for calc()/min()/max()/clamp()/var() vs :is()/:where()/…
     else if (ch === '(') {
-      parenDepth++
+      parenStack.push(isSelectorFunctionParen(result))
       result += ch
       i++
     }
     else if (ch === ')') {
-      parenDepth = Math.max(0, parenDepth - 1)
+      parenStack.pop()
       result += ch
       i++
     }
@@ -115,10 +119,12 @@ export function minifyCSS(code: string): string {
       // strip space before ! for !important
       if (next === '!')
         continue
-      if (parenDepth > 0) {
-        // inside parens (calc/min/max/clamp/var): strip around * and / (safe per spec),
-        // preserve around + and - (required by spec), strip around base punctuation
-        if (prev && next && !isCSSCalcPunctuation(prev) && !isCSSCalcPunctuation(next))
+      if (parenStack.length > 0) {
+        // selector parens (:is/:where/:not/:has) follow selector whitespace rules so
+        // the descendant combinator before * is preserved; value parens (calc/min/…)
+        // may additionally strip around * and / (safe per spec), preserving + and -.
+        const isPunct = parenStack[parenStack.length - 1] ? isCSSPunctuation : isCSSCalcPunctuation
+        if (prev && next && !isPunct(prev) && !isPunct(next))
           result += ' '
       }
       else if (prev && next && !isCSSPunctuation(prev) && !isCSSPunctuation(next)) {
@@ -175,9 +181,28 @@ function isCSSPunctuation(ch: string): boolean {
 }
 
 function isCSSCalcPunctuation(ch: string): boolean {
-  // inside parens: strip spaces around base punctuation and * /
+  // inside value parens: strip spaces around base punctuation and * /
   // but NOT + and - (CSS spec requires spaces around them in calc)
   return isCSSBasePunctuation(ch) || ch === '*' || ch === '/'
+}
+
+function isCSSNameChar(ch: string): boolean {
+  return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch === '-'
+}
+
+// A '(' opens a selector-function paren when it directly follows a functional
+// pseudo-class/element (:is, :where, :not, :has, …). Inside those, * is the
+// universal selector and the leading space is the descendant combinator, so the
+// calc-style stripping of * / must not apply (e.g. Tailwind v4 group-* variants).
+function isSelectorFunctionParen(result: string): boolean {
+  let j = result.length - 1
+  while (j >= 0 && isCSSNameChar(result[j]!))
+    j--
+  if (result[j] !== ':')
+    return false
+  const name = result.slice(j + 1).toLowerCase()
+  return name === 'is' || name === 'where' || name === 'not' || name === 'has'
+    || name === 'matches' || name === 'host' || name === 'host-context' || name === 'slotted'
 }
 
 /**

--- a/test/unit/minify.test.ts
+++ b/test/unit/minify.test.ts
@@ -799,6 +799,23 @@ describe('minifyCSS', () => {
     expect(minifyCSS('* { box-sizing: border-box }')).toBe('*{box-sizing:border-box}')
   })
 
+  // --- selector-function whitespace (#552: Tailwind group-* variants) ---
+
+  it('preserves the descendant combinator space before * inside :is()/:where()', () => {
+    // Tailwind v4 group-* variants emit a universal selector inside :is(:where(.group)…).
+    // The space before * is significant; stripping it produces an invalid selector.
+    expect(minifyCSS('.x{&:is(:where(.group):hover *){color:red}}'))
+      .toBe('.x{&:is(:where(.group):hover *){color:red}}')
+    expect(minifyCSS('.x{&:is(:where(.group)[data-open] *){display:block}}'))
+      .toBe('.x{&:is(:where(.group)[data-open] *){display:block}}')
+  })
+
+  it('still strips spaces around * and / inside value functions like calc()', () => {
+    // value-context parens keep calc minification (regression guard for the #552 fix)
+    expect(minifyCSS('.x { width: calc(100% * 0.5) }')).toBe('.x{width:calc(100%*.5)}')
+    expect(minifyCSS('.x { width: calc(100px / 2) }')).toBe('.x{width:calc(100px/2)}')
+  })
+
   // --- At-rule edge cases ---
 
   it('handles @font-face', () => {


### PR DESCRIPTION
## Problem

`features.inlineStyles` moves component CSS into inline `<style>` tags in the head, where this module's runtime CSS minifier (`minifyCSS`) processes it. That minifier stripped whitespace around `*` inside parens, assuming a `calc()` value context. But Tailwind v4 `group-*` variants emit the universal selector `*` inside `:is(:where(.group):hover *)`, so the significant space before `*` was deleted, producing `:hover*`, an invalid selector that matches nothing.

This only surfaced with `@nuxtjs/seo` (which enables `minify`) **and** `features.inlineStyles: true` combined; either alone was fine. Reported in harlan-zw/nuxt-seo#552.

## Fix

Track paren context in `minifyCSS`. Selector-function parens (`:is`, `:where`, `:not`, `:has`, …) follow selector whitespace rules so the descendant combinator before `*` is preserved; value parens (`calc`, `min`, `max`, `clamp`, `var`) still strip spaces around `*` and `/` for minification.

## Tests

Added unit tests asserting the combinator space survives inside `:is()`/`:where()`, plus a regression guard that `calc()` still strips `*` and `/`. All 227 unit tests pass; lint clean.

Fixes harlan-zw/nuxt-seo#552