### PR TITLE
ci: skip Playwright browser install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,10 @@ permissions:
 jobs:
   ci:
     uses: harlan-zw/nuxt-seo/.github/workflows/reusable-ci.yml@main
+    # No browser tests here; skip the ~183MB arm64 Chromium download that stalls
+    # on cdn.playwright.dev whenever the lockfile cache key misses.
+    with:
+      playwright: false
 
   # The module imports @unhead/vue directly and feature-detects the host's unhead
   # major. The main suite runs on the unhead v3 stack, so it can't catch a v2 host


### PR DESCRIPTION
### 📚 Description

This repo has no browser tests, but the reusable `ci / test` job was installing Chromium on every Playwright-browser cache miss. The cache key is `hashFiles('**/pnpm-lock.yaml')`, so any lockfile change forces a fresh ~183MB arm64 download from `cdn.playwright.dev`, which intermittently stalls at 100%.

Passes `playwright: false` to the reusable workflow (now opt-out via harlan-zw/nuxt-seo#565) to skip the download entirely.

### ❓ Type of change

- [x] 🧹 Chore