### PR TITLE
chore(deps): remove unused semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "nuxtseo-layer-devtools": "catalog:",
     "playwright-core": "catalog:",
     "sass": "catalog:",
-    "semver": "catalog:",
     "sirv": "catalog:",
     "typescript": "catalog:",
     "ultrahtml": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ catalogs:
     scule:
       specifier: ^1.3.0
       version: 1.3.0
-    semver:
-      specifier: ^7.8.5
-      version: 7.8.5
     sharp:
       specifier: ^0.35.3
       version: 0.35.3
@@ -273,9 +270,6 @@ importers:
       sass:
         specifier: 'catalog:'
         version: 1.101.0
-      semver:
-        specifier: 'catalog:'
-        version: 7.8.5
       sirv:
         specifier: 'catalog:'
         version: 3.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,7 +99,6 @@ catalog:
   playwright-core: ^1.61.1
   sass: ^1.101.0
   scule: ^1.3.0
-  semver: ^7.8.5
   sharp: ^0.35.3
   sirv: ^3.0.2
   tinyglobby: ^0.2.17


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Removes the unused semver development dependency from package.json and the pnpm catalog. No source or test files import it.
