### PR TITLE
chore: code cleanup sweep

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "nuxtseo-layer-devtools": "catalog:",
     "playwright-core": "catalog:",
     "sass": "catalog:",
-    "sirv": "catalog:",
     "typescript": "catalog:",
     "ultrahtml": "catalog:",
     "unbuild": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,9 +111,6 @@ catalogs:
     sharp:
       specifier: ^0.35.3
       version: 0.35.3
-    sirv:
-      specifier: ^3.0.2
-      version: 3.0.2
     tinyglobby:
       specifier: ^0.2.17
       version: 0.2.17
@@ -270,9 +267,6 @@ importers:
       sass:
         specifier: 'catalog:'
         version: 1.101.0
-      sirv:
-        specifier: 'catalog:'
-        version: 3.0.2
       typescript:
         specifier: 'catalog:'
         version: 6.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -100,7 +100,6 @@ catalog:
   sass: ^1.101.0
   scule: ^1.3.0
   sharp: ^0.35.3
-  sirv: ^3.0.2
   tinyglobby: ^0.2.17
   typescript: 6.0.3
   ufo: ^1.6.4

--- a/src/build-time/generateTagsFromPageDirImages.ts
+++ b/src/build-time/generateTagsFromPageDirImages.ts
@@ -1,8 +1,7 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { UseSeoMetaInput } from '@unhead/vue/types'
 import fs from 'node:fs'
-import { useNuxt } from '@nuxt/kit'
-import { defu } from 'defu'
+import { extendRouteRules, useNuxt } from '@nuxt/kit'
 import { basename, dirname, resolve } from 'pathe'
 import { glob } from 'tinyglobby'
 import { joinURL } from 'ufo'
@@ -61,8 +60,8 @@ export default async function generateTagsFromPageDirImages(nuxt: Nuxt = useNuxt
     }
   }
 
-  nuxt.options.routeRules = defu(appendRouteRules, nuxt.options.routeRules)
-  nuxt.options.nitro.routeRules = defu(appendRouteRules, nuxt.options.nitro.routeRules)
+  for (const [route, rule] of Object.entries(appendRouteRules))
+    extendRouteRules(route, rule, { override: true })
 
   if (nuxt.options.dev) {
     nuxt.hooks.hook('nitro:config', async (nitroConfig) => {

--- a/src/build-time/minifyStaticHead.ts
+++ b/src/build-time/minifyStaticHead.ts
@@ -1,7 +1,5 @@
 import { useLogger, useNuxt } from '@nuxt/kit'
-
-const JSON_TYPES = new Set(['application/json', 'application/ld+json'])
-const SKIP_JS_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
+import { JSON_TYPES, SKIP_JS_TYPES } from '../runtime/shared/minify'
 
 const logger = useLogger('nuxt-seo-utils')
 

--- a/src/build-time/setupNuxtConfigAppHeadWithMoreDefaults.ts
+++ b/src/build-time/setupNuxtConfigAppHeadWithMoreDefaults.ts
@@ -8,7 +8,6 @@ export default function setupNuxtConfigAppHeadWithMoreDefaults(nuxt: Nuxt = useN
   const headConfig = nuxt.options.app.head
   headConfig.link = headConfig.link || []
   headConfig.htmlAttrs = headConfig.htmlAttrs || {}
-  headConfig.link = headConfig.link || []
   headConfig.meta = headConfig.meta || []
 
   if (!hasMetaProperty(headConfig, 'og:type')) {

--- a/src/pageUtils.ts
+++ b/src/pageUtils.ts
@@ -167,10 +167,6 @@ function parseSegment(segment: string): SegmentToken[] {
         else if (PARAM_CHAR_RE.test(c)) {
           buffer += c
         }
-        else {
-
-          // console.debug(`[pages]Ignored character "${c}" while building param "${buffer}" from "segment"`)
-        }
         break
     }
     i++

--- a/src/runtime/app/plugins/minifyScripts.server.ts
+++ b/src/runtime/app/plugins/minifyScripts.server.ts
@@ -1,9 +1,6 @@
 import { injectHead } from '@unhead/vue'
 import { defineNuxtPlugin } from 'nuxt/app'
-import { minifyCSS, minifyJS, minifyJSON } from '../../shared/minify'
-
-const JSON_TYPES = new Set(['application/json', 'application/ld+json'])
-const SKIP_JS_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
+import { JSON_TYPES, minifyCSS, minifyJS, minifyJSON, SKIP_JS_TYPES } from '../../shared/minify'
 
 export default defineNuxtPlugin({
   enforce: 'post',

--- a/src/runtime/server/plugins/minifyHtml.ts
+++ b/src/runtime/server/plugins/minifyHtml.ts
@@ -1,11 +1,9 @@
 import { defineNitroPlugin } from 'nitropack/runtime'
-import { minifyCSS, minifyJS, minifyJSON } from '../../shared/minify'
+import { JSON_TYPES, minifyCSS, minifyJS, minifyJSON, SKIP_JS_TYPES } from '../../shared/minify'
 
 const INLINE_SCRIPT_RE = /<script(?![^>]+\bsrc\b)([^>]*)>([\s\S]*?)<\/script\s*>/gi
 const INLINE_STYLE_RE = /<style([^>]*)>([\s\S]*?)<\/style\s*>/gi
 const TYPE_ATTR_RE = /\btype\s*=\s*["']([^"']*)["']/i
-const JSON_TYPES = new Set(['application/json', 'application/ld+json'])
-const SKIP_JS_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
 
 function minifyChunk(chunk: string): string {
   let out = chunk.replace(INLINE_SCRIPT_RE, (full, attrs: string, content: string) => {

--- a/src/runtime/shared/minify.ts
+++ b/src/runtime/shared/minify.ts
@@ -1,3 +1,6 @@
+export const JSON_TYPES = new Set(['application/json', 'application/ld+json'])
+export const SKIP_JS_TYPES = new Set(['application/json', 'application/ld+json', 'speculationrules', 'importmap'])
+
 /**
  * Lightweight JS minifier in pure JS (no native deps).
  * Strips comments and collapses whitespace while preserving string literals.

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,15 +54,3 @@ export async function getImageDimensions(absolutePath: string): Promise<{ width:
   const buffer = await readFile(absolutePath)
   return imageSize(buffer)
 }
-
-export async function getImageDimensionsToSizes(absolutePath: string): Promise<string> {
-  try {
-    // read the file into a buffer using fs
-    const { width, height } = await getImageDimensions(absolutePath)
-    return `${width}x${height}`
-  }
-  catch {
-    // Image metadata is optional for icons; fall back to the generic size token.
-  }
-  return 'any'
-}


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore

### 📚 Description

Swept `src/` for dead code and duplication, and modernized one spot to use a `@nuxt/kit` 4.5 built-in. No public API or behavior changes.

- `util.ts`: removed `getImageDimensionsToSizes`, an unused export
- `pageUtils.ts`: removed a leftover commented-out debug log
- `setupNuxtConfigAppHeadWithMoreDefaults.ts`: removed a duplicate `headConfig.link` assignment
- Consolidated `JSON_TYPES`/`SKIP_JS_TYPES`, previously duplicated identically in `minifyStaticHead.ts`, `minifyScripts.server.ts`, and `minifyHtml.ts`, into `runtime/shared/minify.ts`
- Removed the unused `sirv` devDependency (verified via grep across the repo, not just `src/`)
- `generateTagsFromPageDirImages.ts`: replaced the manual `defu()` merge of `nuxt.options.routeRules`/`nuxt.options.nitro.routeRules` with `@nuxt/kit`'s `extendRouteRules(route, rule, { override: true })`, verified behavior-equivalent against the kit source

Note: `semver` is also unused but is left alone since `chore/migrate-semver-to-verkit` already handles its removal.

I also checked `setGlobalHead()`, `updateRuntimeConfig()`, and `getLayerDirectories()` as candidate kit modernizations for the other `app.head`/`runtimeConfig`/`_layers` call sites, but each would change behavior (head tag order, client runtime config exposure, and pages/public dir resolution respectively), so I left those alone.

Verified: lint, typecheck, full test suite (245/245), and `pnpm build` all pass.