### PR TITLE
perf: make Unhead bundler an optional peer

### DIFF
--- a/docs/content/3.api/0.config.md
+++ b/docs/content/3.api/0.config.md
@@ -117,6 +117,8 @@ JSON script types (`application/ld+json`, `application/json`) are minified via J
 
 Attempts to treeshake the `useSeoMeta` function. Can save around 5kb in the client bundle.
 
+Unhead v2 users must install the optional `@unhead/bundler` peer to enable this transform. Unhead v3 provides it through `@unhead/vue`.
+
 ## `extendRouteRules: boolean`{lang="ts"}
 
 - Default: `true`{lang="ts"}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
       "@unhead/vue",
       "@unhead/vue/plugins",
       "@unhead/vue/utils",
-      "@unhead/vue/vite",
-      "@unhead/bundler/vite"
+      "@unhead/vue/vite"
     ]
   },
   "scripts": {
@@ -58,6 +57,7 @@
     "test:compat-v2": "node test/compat-v2/run.mjs"
   },
   "peerDependencies": {
+    "@unhead/bundler": "^3.2.1",
     "@unhead/vue": "^2.0.7 || ^3.0.0",
     "esbuild": ">=0.17.0",
     "lightningcss": ">=1.20.0",
@@ -66,6 +66,9 @@
     "unhead": "^2.0.7 || ^3.0.0"
   },
   "peerDependenciesMeta": {
+    "@unhead/bundler": {
+      "optional": true
+    },
     "@unhead/vue": {
       "optional": true
     },
@@ -84,7 +87,6 @@
   },
   "dependencies": {
     "@nuxt/kit": "catalog:",
-    "@unhead/bundler": "catalog:",
     "citty": "catalog:",
     "consola": "catalog:",
     "defu": "catalog:",
@@ -111,6 +113,7 @@
     "@nuxt/ui": "catalog:",
     "@nuxtjs/i18n": "catalog:",
     "@types/node": "catalog:",
+    "@unhead/bundler": "catalog:",
     "@unhead/vue": "catalog:",
     "@vue/test-utils": "catalog:",
     "bumpp": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,9 +146,6 @@ importers:
       '@nuxt/kit':
         specifier: 'catalog:'
         version: 4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.1.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)))
-      '@unhead/bundler':
-        specifier: 3.2.1
-        version: 3.2.1(crossws@0.4.6(srvx@0.11.22))(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.1.0)(rollup@4.61.1)(typescript@6.0.3)(unhead@3.2.1(esbuild@0.28.0)(rolldown@1.1.0)(rollup@4.61.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
       citty:
         specifier: 'catalog:'
         version: 0.2.2
@@ -222,6 +219,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.1
+      '@unhead/bundler':
+        specifier: 3.2.1
+        version: 3.2.1(crossws@0.4.6(srvx@0.11.22))(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.1.0)(rollup@4.61.1)(typescript@6.0.3)(unhead@3.2.1(esbuild@0.28.0)(rolldown@1.1.0)(rollup@4.61.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))
       '@unhead/vue':
         specifier: 3.2.1
         version: 3.2.1(crossws@0.4.6(srvx@0.11.22))(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.1.0)(rollup@4.61.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,7 +72,7 @@ catalog:
   '@nuxt/ui': ^4.10.0
   '@nuxtjs/i18n': ^10.4.1
   '@types/node': ^26.1.1
-  '@unhead/bundler': 3.2.1
+  '@unhead/bundler': ^3.2.1
   '@unhead/vue': 3.2.1
   '@vue/test-utils': ^2.4.11
   bumpp: ^11.1.0

--- a/src/module.ts
+++ b/src/module.ts
@@ -401,7 +401,7 @@ export {}
       && await hasNuxtCompatibility({ nuxt: '>=4.5.0' })
     if (!nuxtRegistersUnheadVite && viteOpts !== false) {
       // v3 ships the plugin via @unhead/vue/vite (wraps bundler + adds vue streaming).
-      // v2 has no such entry, so we fall back to our bundled @unhead/bundler/vite.
+      // v2 has no such entry, so it can use the optional @unhead/bundler peer.
       // Detect the major the host actually *renders* with, not whichever @unhead/vue
       // resolves from rootDir: under pnpm a nested @unhead/vue v2 can sit at the root
       // while Nitro/Nuxt render with unhead v3. Picking the wrong major makes the
@@ -415,6 +415,15 @@ export {}
       const lightningcssPath = resolveModulePath('lightningcss', { try: true, from: importPaths })
       const rolldownURL = rolldownPath ? pathToFileURL(rolldownPath).href : undefined
       const lightningcssURL = lightningcssPath ? pathToFileURL(lightningcssPath).href : undefined
+      const bundlerPath = unheadMajor < 3
+        ? resolveModulePath('@unhead/bundler/vite', { try: true, from: importPaths })
+        : undefined
+      const bundlerURL = bundlerPath ? pathToFileURL(bundlerPath).href : undefined
+      const vitePluginSource = unheadMajor >= 3
+        ? { _tag: 'vue' } as const
+        : bundlerURL
+          ? { _tag: 'bundler', url: bundlerURL } as const
+          : { _tag: 'missing-bundler' } as const
       const minify = {
         js: rolldownURL
           ? async (code: string) => {
@@ -433,24 +442,29 @@ export {}
           }
           : undefined,
       }
-      addVitePlugin(async () => {
-        if (unheadMajor >= 3) {
-          const v3Vite = '@unhead/vue/vite'
-          const { Unhead } = await import(v3Vite) as { Unhead: (opts?: Record<string, any>) => any }
-          return Unhead({ minify, ...viteOpts })
-        }
-        // v2 runtime: keep validate/devtools disabled (ValidatePlugin and devtoolsPlugin
-        // target v3 plugin API); minify is pure build-time so safe to enable.
-        const { Unhead } = await import('@unhead/bundler/vite')
-        return Unhead({
-          _framework: '@unhead/vue',
-          minify,
-          validate: false,
-          devtools: false,
+      if (vitePluginSource._tag === 'missing-bundler') {
+        logger.warn('`treeShakeUseSeoMeta` requires the optional `@unhead/bundler` peer on Unhead v2. Install it or disable `treeShakeUseSeoMeta`.')
+      }
+      else {
+        addVitePlugin(async () => {
+          if (vitePluginSource._tag === 'vue') {
+            const v3Vite = '@unhead/vue/vite'
+            const { Unhead } = await import(v3Vite) as { Unhead: (opts?: Record<string, any>) => any }
+            return Unhead({ minify, ...viteOpts })
+          }
+          // v2 runtime: keep validate/devtools disabled (ValidatePlugin and devtoolsPlugin
+          // target v3 plugin API); minify is pure build-time so safe to enable.
+          const { Unhead } = await import(vitePluginSource.url) as { Unhead: (opts?: Record<string, any>) => any }
+          return Unhead({
+            _framework: '@unhead/vue',
+            minify,
+            validate: false,
+            devtools: false,
+          })
+        }, {
+          prepend: true,
         })
-      }, {
-        prepend: true,
-      })
+      }
     }
     if (config.automaticOgAndTwitterTags)
       addPlugin({ src: resolve(appRuntimeDir, 'plugins', 'inferSeoMetaPlugin') })

--- a/test/compat-v2/README.md
+++ b/test/compat-v2/README.md
@@ -5,9 +5,10 @@ pins `@unhead/vue`/`unhead` to v3 so Nuxt's renderer stays coherent). This fixtu
 guards the **v2** stack, which can't coexist in the same workspace because the
 unhead major is global.
 
-It is a standalone npm project (excluded from the pnpm workspace) that installs a
-v2 host — Nuxt 4.2, `@unhead/vue@2`, `unhead@2` — and links the local module via
-`file:module.tgz`. The module imports `@unhead/vue` directly (`/plugins`,
+It is a standalone npm project (excluded from the pnpm workspace) that links the
+local module via `file:module.tgz`. It installs a v2 host with Nuxt 4.2,
+`@unhead/vue@2`, and `unhead@2`, plus the optional `@unhead/bundler` peer. The
+module imports `@unhead/vue` directly (`/plugins`,
 `/utils`, `/vite`) and feature-detects the host's unhead major; a successful
 render proves those imports resolve on v2 and that the `InferSeoMetaPlugin` and
 `TemplateParamsPlugin` runtime registrations still run.

--- a/test/compat-v2/package.template.json
+++ b/test/compat-v2/package.template.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "nuxt-seo-utils": "file:module.tgz",
     "nuxt": "~4.2.0",
+    "@unhead/bundler": "^3.2.1",
     "@unhead/vue": "^2.0.7",
     "unhead": "^2.0.7"
   },


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`@unhead/bundler` was installed as a production dependency even though `@unhead/vue` v3 already exposes `@unhead/vue/vite`. This moves Bundler to a caret-ranged optional peer, resolves it only for Unhead v2, and warns before skipping the transform when that peer is absent.