### PR TITLE
fix: resolve Unhead Vite plugin from host tree

### DIFF
--- a/docs/content/3.api/0.config.md
+++ b/docs/content/3.api/0.config.md
@@ -117,7 +117,7 @@ JSON script types (`application/ld+json`, `application/json`) are minified via J
 
 Attempts to treeshake the `useSeoMeta` function. Can save around 5kb in the client bundle.
 
-Unhead v2 users must install the optional `@unhead/bundler` peer to enable this transform. Unhead v3 provides it through `@unhead/vue`.
+Unhead v2 users must install the optional `@unhead/bundler@~3.2.1` peer to enable this transform. Unhead v3 provides it through `@unhead/vue`.
 
 ## `extendRouteRules: boolean`{lang="ts"}
 

--- a/docs/content/3.api/0.config.md
+++ b/docs/content/3.api/0.config.md
@@ -117,8 +117,6 @@ JSON script types (`application/ld+json`, `application/json`) are minified via J
 
 Attempts to treeshake the `useSeoMeta` function. Can save around 5kb in the client bundle.
 
-Unhead v2 users must install the optional `@unhead/bundler@~3.2.1` peer to enable this transform. Unhead v3 provides it through `@unhead/vue`.
-
 ## `extendRouteRules: boolean`{lang="ts"}
 
 - Default: `true`{lang="ts"}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "test:compat-v2": "node test/compat-v2/run.mjs"
   },
   "peerDependencies": {
-    "@unhead/bundler": "^3.2.1",
     "@unhead/vue": "^2.0.7 || ^3.0.0",
     "esbuild": ">=0.17.0",
     "lightningcss": ">=1.20.0",
@@ -66,9 +65,6 @@
     "unhead": "^2.0.7 || ^3.0.0"
   },
   "peerDependenciesMeta": {
-    "@unhead/bundler": {
-      "optional": true
-    },
     "@unhead/vue": {
       "optional": true
     },
@@ -113,7 +109,6 @@
     "@nuxt/ui": "catalog:",
     "@nuxtjs/i18n": "catalog:",
     "@types/node": "catalog:",
-    "@unhead/bundler": "catalog:",
     "@unhead/vue": "catalog:",
     "@vue/test-utils": "catalog:",
     "bumpp": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,9 +219,6 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 26.1.2
-      '@unhead/bundler':
-        specifier: 3.2.1
-        version: 3.2.1(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.61.1)(typescript@6.0.3)(unhead@3.2.1(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.61.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.48.0)(yaml@2.9.0)))(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.48.0)(yaml@2.9.0))
       '@unhead/vue':
         specifier: 3.2.1
         version: 3.2.1(crossws@0.4.10(srvx@0.11.22))(esbuild@0.28.0)(lightningcss@1.32.0)(rolldown@1.2.0)(rollup@4.61.1)(typescript@6.0.3)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -72,7 +72,6 @@ catalog:
   '@nuxt/ui': ^4.10.0
   '@nuxtjs/i18n': ^10.5.0
   '@types/node': ^26.1.2
-  '@unhead/bundler': ^3.2.3
   '@unhead/vue': 3.2.3
   '@vue/test-utils': ^2.4.11
   bumpp: ^12.0.0

--- a/src/build-time/resolveUnheadVitePluginSource.ts
+++ b/src/build-time/resolveUnheadVitePluginSource.ts
@@ -1,0 +1,48 @@
+import { pathToFileURL } from 'node:url'
+
+export type UnheadVitePluginSource
+  = | { _tag: 'vue', url: string }
+    | { _tag: 'bundler', url: string }
+    | { _tag: 'missing-vue' }
+    | { _tag: 'missing-bundler' }
+
+interface ResolveOptions {
+  try: true
+  from: URL[]
+}
+
+interface ResolveUnheadVitePluginSourceInput {
+  unheadMajor: 2 | 3
+  hostImportPaths: URL[]
+  importPaths: URL[]
+}
+
+type ResolvePath = (id: string, options: ResolveOptions) => string | undefined
+
+export function supportsUnheadV2Bundler(version: string): boolean {
+  const [major, minor] = version.split('.')
+  return major === '3' && minor === '2'
+}
+
+export function resolveUnheadVitePluginSource(
+  input: ResolveUnheadVitePluginSourceInput,
+  resolvePath: ResolvePath,
+): UnheadVitePluginSource {
+  if (input.unheadMajor >= 3) {
+    const path = resolvePath('@unhead/vue/vite', {
+      try: true,
+      from: [...input.hostImportPaths, ...input.importPaths],
+    })
+    return path
+      ? { _tag: 'vue', url: pathToFileURL(path).href }
+      : { _tag: 'missing-vue' }
+  }
+
+  const path = resolvePath('@unhead/bundler/vite', {
+    try: true,
+    from: input.importPaths,
+  })
+  return path
+    ? { _tag: 'bundler', url: pathToFileURL(path).href }
+    : { _tag: 'missing-bundler' }
+}

--- a/src/build-time/resolveUnheadVitePluginSource.ts
+++ b/src/build-time/resolveUnheadVitePluginSource.ts
@@ -2,9 +2,8 @@ import { pathToFileURL } from 'node:url'
 
 export type UnheadVitePluginSource
   = | { _tag: 'vue', url: string }
-    | { _tag: 'bundler', url: string }
     | { _tag: 'missing-vue' }
-    | { _tag: 'missing-bundler' }
+    | { _tag: 'unsupported-v2' }
 
 interface ResolveOptions {
   try: true
@@ -19,30 +18,18 @@ interface ResolveUnheadVitePluginSourceInput {
 
 type ResolvePath = (id: string, options: ResolveOptions) => string | undefined
 
-export function supportsUnheadV2Bundler(version: string): boolean {
-  const [major, minor] = version.split('.')
-  return major === '3' && minor === '2'
-}
-
 export function resolveUnheadVitePluginSource(
   input: ResolveUnheadVitePluginSourceInput,
   resolvePath: ResolvePath,
 ): UnheadVitePluginSource {
-  if (input.unheadMajor >= 3) {
-    const path = resolvePath('@unhead/vue/vite', {
-      try: true,
-      from: [...input.hostImportPaths, ...input.importPaths],
-    })
-    return path
-      ? { _tag: 'vue', url: pathToFileURL(path).href }
-      : { _tag: 'missing-vue' }
-  }
+  if (input.unheadMajor < 3)
+    return { _tag: 'unsupported-v2' }
 
-  const path = resolvePath('@unhead/bundler/vite', {
+  const path = resolvePath('@unhead/vue/vite', {
     try: true,
-    from: input.importPaths,
+    from: [...input.hostImportPaths, ...input.importPaths],
   })
   return path
-    ? { _tag: 'bundler', url: pathToFileURL(path).href }
-    : { _tag: 'missing-bundler' }
+    ? { _tag: 'vue', url: pathToFileURL(path).href }
+    : { _tag: 'missing-vue' }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,13 +17,14 @@ import { defu } from 'defu'
 import { resolveModulePath } from 'exsolve'
 import { installNuxtSiteConfig } from 'nuxt-site-config/kit'
 import { resolveHostUnheadMajor, useModuleLogger } from 'nuxtseo-shared/kit'
-import { relative } from 'pathe'
-import { readPackageJSON } from 'pkg-types'
+import { dirname, relative } from 'pathe'
+import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 import extendNuxtConfigAppHeadSeoMeta from './build-time/extendNuxtConfigAppHeadSeoMeta'
 import extendNuxtConfigAppHeadTypes from './build-time/extendNuxtConfigAppHeadTypes'
 import generateTagsFromPageDirImages from './build-time/generateTagsFromPageDirImages'
 import generateTagsFromPublicFiles from './build-time/generateTagsFromPublicFiles'
 import minifyStaticHead from './build-time/minifyStaticHead'
+import { resolveUnheadVitePluginSource, supportsUnheadV2Bundler } from './build-time/resolveUnheadVitePluginSource'
 import setupNuxtConfigAppHeadWithMoreDefaults from './build-time/setupNuxtConfigAppHeadWithMoreDefaults'
 import { setupDevToolsUI } from './build/devtools'
 
@@ -415,15 +416,19 @@ export {}
       const lightningcssPath = resolveModulePath('lightningcss', { try: true, from: importPaths })
       const rolldownURL = rolldownPath ? pathToFileURL(rolldownPath).href : undefined
       const lightningcssURL = lightningcssPath ? pathToFileURL(lightningcssPath).href : undefined
-      const bundlerPath = unheadMajor < 3
-        ? resolveModulePath('@unhead/bundler/vite', { try: true, from: importPaths })
-        : undefined
-      const bundlerURL = bundlerPath ? pathToFileURL(bundlerPath).href : undefined
-      const vitePluginSource = unheadMajor >= 3
-        ? { _tag: 'vue' } as const
-        : bundlerURL
-          ? { _tag: 'bundler', url: bundlerURL } as const
-          : { _tag: 'missing-bundler' } as const
+      const hostImportPaths = unheadMajor >= 3
+        ? [directoryToURL(dirname(await resolvePackageJSON('nuxt', { url: directoryToURL(nuxt.options.rootDir).href })))]
+        : []
+      const resolvedVitePluginSource = resolveUnheadVitePluginSource({
+        unheadMajor,
+        hostImportPaths,
+        importPaths,
+      }, resolveModulePath)
+      const vitePluginSource = resolvedVitePluginSource._tag === 'bundler'
+        ? await readPackageJSON(resolvedVitePluginSource.url).then(({ version }) => version && supportsUnheadV2Bundler(version)
+            ? resolvedVitePluginSource
+            : { _tag: 'incompatible-bundler', version: version || 'unknown' } as const)
+        : resolvedVitePluginSource
       const minify = {
         js: rolldownURL
           ? async (code: string) => {
@@ -442,19 +447,23 @@ export {}
           }
           : undefined,
       }
-      if (vitePluginSource._tag === 'missing-bundler') {
+      if (vitePluginSource._tag === 'missing-vue') {
+        logger.warn('`treeShakeUseSeoMeta` requires `@unhead/vue` with the `/vite` export. Install Unhead v3 or disable `treeShakeUseSeoMeta`.')
+      }
+      else if (vitePluginSource._tag === 'missing-bundler') {
         logger.warn('`treeShakeUseSeoMeta` requires the optional `@unhead/bundler` peer on Unhead v2. Install it or disable `treeShakeUseSeoMeta`.')
+      }
+      else if (vitePluginSource._tag === 'incompatible-bundler') {
+        logger.warn(`\`treeShakeUseSeoMeta\` requires \`@unhead/bundler@3.2.x\` on Unhead v2. Found ${vitePluginSource.version}; skipping the transform.`)
       }
       else {
         addVitePlugin(async () => {
+          const { Unhead } = await import(vitePluginSource.url) as { Unhead: (opts?: Record<string, any>) => any }
           if (vitePluginSource._tag === 'vue') {
-            const v3Vite = '@unhead/vue/vite'
-            const { Unhead } = await import(v3Vite) as { Unhead: (opts?: Record<string, any>) => any }
             return Unhead({ minify, ...viteOpts })
           }
           // v2 runtime: keep validate/devtools disabled (ValidatePlugin and devtoolsPlugin
           // target v3 plugin API); minify is pure build-time so safe to enable.
-          const { Unhead } = await import(vitePluginSource.url) as { Unhead: (opts?: Record<string, any>) => any }
           return Unhead({
             _framework: '@unhead/vue',
             minify,

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,7 +24,7 @@ import extendNuxtConfigAppHeadTypes from './build-time/extendNuxtConfigAppHeadTy
 import generateTagsFromPageDirImages from './build-time/generateTagsFromPageDirImages'
 import generateTagsFromPublicFiles from './build-time/generateTagsFromPublicFiles'
 import minifyStaticHead from './build-time/minifyStaticHead'
-import { resolveUnheadVitePluginSource, supportsUnheadV2Bundler } from './build-time/resolveUnheadVitePluginSource'
+import { resolveUnheadVitePluginSource } from './build-time/resolveUnheadVitePluginSource'
 import setupNuxtConfigAppHeadWithMoreDefaults from './build-time/setupNuxtConfigAppHeadWithMoreDefaults'
 import { setupDevToolsUI } from './build/devtools'
 
@@ -401,8 +401,6 @@ export {}
       && nuxt.options.builder === '@nuxt/vite-builder'
       && await hasNuxtCompatibility({ nuxt: '>=4.5.0' })
     if (!nuxtRegistersUnheadVite && viteOpts !== false) {
-      // v3 ships the plugin via @unhead/vue/vite (wraps bundler + adds vue streaming).
-      // v2 has no such entry, so it can use the optional @unhead/bundler peer.
       // Detect the major the host actually *renders* with, not whichever @unhead/vue
       // resolves from rootDir: under pnpm a nested @unhead/vue v2 can sit at the root
       // while Nitro/Nuxt render with unhead v3. Picking the wrong major makes the
@@ -419,16 +417,11 @@ export {}
       const hostImportPaths = unheadMajor >= 3
         ? [directoryToURL(dirname(await resolvePackageJSON('nuxt', { url: directoryToURL(nuxt.options.rootDir).href })))]
         : []
-      const resolvedVitePluginSource = resolveUnheadVitePluginSource({
+      const vitePluginSource = resolveUnheadVitePluginSource({
         unheadMajor,
         hostImportPaths,
         importPaths,
       }, resolveModulePath)
-      const vitePluginSource = resolvedVitePluginSource._tag === 'bundler'
-        ? await readPackageJSON(resolvedVitePluginSource.url).then(({ version }) => version && supportsUnheadV2Bundler(version)
-            ? resolvedVitePluginSource
-            : { _tag: 'incompatible-bundler', version: version || 'unknown' } as const)
-        : resolvedVitePluginSource
       const minify = {
         js: rolldownURL
           ? async (code: string) => {
@@ -447,29 +440,16 @@ export {}
           }
           : undefined,
       }
-      if (vitePluginSource._tag === 'missing-vue') {
+      if (vitePluginSource._tag === 'unsupported-v2') {
+        logger.warn('`treeShakeUseSeoMeta` requires Unhead v3; skipping the transform on Unhead v2.')
+      }
+      else if (vitePluginSource._tag === 'missing-vue') {
         logger.warn('`treeShakeUseSeoMeta` requires `@unhead/vue` with the `/vite` export. Install Unhead v3 or disable `treeShakeUseSeoMeta`.')
-      }
-      else if (vitePluginSource._tag === 'missing-bundler') {
-        logger.warn('`treeShakeUseSeoMeta` requires the optional `@unhead/bundler` peer on Unhead v2. Install it or disable `treeShakeUseSeoMeta`.')
-      }
-      else if (vitePluginSource._tag === 'incompatible-bundler') {
-        logger.warn(`\`treeShakeUseSeoMeta\` requires \`@unhead/bundler@3.2.x\` on Unhead v2. Found ${vitePluginSource.version}; skipping the transform.`)
       }
       else {
         addVitePlugin(async () => {
           const { Unhead } = await import(vitePluginSource.url) as { Unhead: (opts?: Record<string, any>) => any }
-          if (vitePluginSource._tag === 'vue') {
-            return Unhead({ minify, ...viteOpts })
-          }
-          // v2 runtime: keep validate/devtools disabled (ValidatePlugin and devtoolsPlugin
-          // target v3 plugin API); minify is pure build-time so safe to enable.
-          return Unhead({
-            _framework: '@unhead/vue',
-            minify,
-            validate: false,
-            devtools: false,
-          })
+          return Unhead({ minify, ...viteOpts })
         }, {
           prepend: true,
         })

--- a/test/compat-v2/README.md
+++ b/test/compat-v2/README.md
@@ -7,10 +7,9 @@ unhead major is global.
 
 It is a standalone npm project (excluded from the pnpm workspace) that links the
 local module via `file:module.tgz`. It installs a v2 host with Nuxt 4.2,
-`@unhead/vue@2`, and `unhead@2`, plus the optional `@unhead/bundler` peer. The
-module imports `@unhead/vue` directly (`/plugins`,
-`/utils`, `/vite`) and feature-detects the host's unhead major; a successful
-render proves those imports resolve on v2 and that the `InferSeoMetaPlugin` and
+`@unhead/vue@2`, and `unhead@2`. The module imports `@unhead/vue` directly
+through its v2 exports and skips the v3-only Vite transform. A successful render
+proves those imports resolve on v2 and that the `InferSeoMetaPlugin` and
 `TemplateParamsPlugin` runtime registrations still run.
 
 ## Run

--- a/test/compat-v2/package.template.json
+++ b/test/compat-v2/package.template.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "nuxt-seo-utils": "file:module.tgz",
     "nuxt": "~4.2.0",
-    "@unhead/bundler": "~3.2.1",
     "@unhead/vue": "^2.0.7",
     "unhead": "^2.0.7"
   },

--- a/test/compat-v2/package.template.json
+++ b/test/compat-v2/package.template.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "nuxt-seo-utils": "file:module.tgz",
     "nuxt": "~4.2.0",
-    "@unhead/bundler": "^3.2.1",
+    "@unhead/bundler": "~3.2.1",
     "@unhead/vue": "^2.0.7",
     "unhead": "^2.0.7"
   },

--- a/test/unit/unheadVitePluginSource.test.ts
+++ b/test/unit/unheadVitePluginSource.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveUnheadVitePluginSource, supportsUnheadV2Bundler } from '../../src/build-time/resolveUnheadVitePluginSource'
+
+describe('resolveUnheadVitePluginSource', () => {
+  it('resolves the v3 plugin from the Nuxt dependency tree before the app root', () => {
+    const hostImportPath = new URL('file:///app/node_modules/nuxt/')
+    const appImportPath = new URL('file:///app/node_modules/')
+    const resolvePath = vi.fn(() => '/app/node_modules/nuxt/node_modules/@unhead/vue/dist/vite.mjs')
+
+    const source = resolveUnheadVitePluginSource({
+      unheadMajor: 3,
+      hostImportPaths: [hostImportPath],
+      importPaths: [appImportPath],
+    }, resolvePath)
+
+    expect(resolvePath).toHaveBeenCalledWith('@unhead/vue/vite', {
+      try: true,
+      from: [hostImportPath, appImportPath],
+    })
+    expect(source).toEqual({
+      _tag: 'vue',
+      url: 'file:///app/node_modules/nuxt/node_modules/@unhead/vue/dist/vite.mjs',
+    })
+  })
+
+  it('keeps resolving the v2 plugin from the optional bundler peer', () => {
+    const appImportPath = new URL('file:///app/node_modules/')
+    const resolvePath = vi.fn(() => '/app/node_modules/@unhead/bundler/dist/vite.mjs')
+
+    const source = resolveUnheadVitePluginSource({
+      unheadMajor: 2,
+      hostImportPaths: [],
+      importPaths: [appImportPath],
+    }, resolvePath)
+
+    expect(resolvePath).toHaveBeenCalledWith('@unhead/bundler/vite', {
+      try: true,
+      from: [appImportPath],
+    })
+    expect(source).toEqual({
+      _tag: 'bundler',
+      url: 'file:///app/node_modules/@unhead/bundler/dist/vite.mjs',
+    })
+  })
+
+  it('rejects bundler versions that require Unhead v3 exports', () => {
+    expect(supportsUnheadV2Bundler('3.2.1')).toBe(true)
+    expect(supportsUnheadV2Bundler('3.3.0')).toBe(false)
+  })
+})

--- a/test/unit/unheadVitePluginSource.test.ts
+++ b/test/unit/unheadVitePluginSource.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { resolveUnheadVitePluginSource, supportsUnheadV2Bundler } from '../../src/build-time/resolveUnheadVitePluginSource'
+import { resolveUnheadVitePluginSource } from '../../src/build-time/resolveUnheadVitePluginSource'
 
 describe('resolveUnheadVitePluginSource', () => {
   it('resolves the v3 plugin from the Nuxt dependency tree before the app root', () => {
@@ -23,9 +23,9 @@ describe('resolveUnheadVitePluginSource', () => {
     })
   })
 
-  it('keeps resolving the v2 plugin from the optional bundler peer', () => {
+  it('skips the v3-only transform on Unhead v2', () => {
     const appImportPath = new URL('file:///app/node_modules/')
-    const resolvePath = vi.fn(() => '/app/node_modules/@unhead/bundler/dist/vite.mjs')
+    const resolvePath = vi.fn()
 
     const source = resolveUnheadVitePluginSource({
       unheadMajor: 2,
@@ -33,18 +33,7 @@ describe('resolveUnheadVitePluginSource', () => {
       importPaths: [appImportPath],
     }, resolvePath)
 
-    expect(resolvePath).toHaveBeenCalledWith('@unhead/bundler/vite', {
-      try: true,
-      from: [appImportPath],
-    })
-    expect(source).toEqual({
-      _tag: 'bundler',
-      url: 'file:///app/node_modules/@unhead/bundler/dist/vite.mjs',
-    })
-  })
-
-  it('rejects bundler versions that require Unhead v3 exports', () => {
-    expect(supportsUnheadV2Bundler('3.2.1')).toBe(true)
-    expect(supportsUnheadV2Bundler('3.3.0')).toBe(false)
+    expect(resolvePath).not.toHaveBeenCalled()
+    expect(source).toEqual({ _tag: 'unsupported-v2' })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #126

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The Vite plugin could resolve from the app dependency tree, selecting `@unhead/vue@2` even when Nuxt renders with Unhead v3. Resolve the v3 plugin from Nuxt's dependency tree first. On v2 hosts, `treeShakeUseSeoMeta` now skips without loading `@unhead/bundler`.
