### PR TITLE
feat: switch icons with app color mode

### DIFF
--- a/docs/content/2.guides/1.app-icons.md
+++ b/docs/content/2.guides/1.app-icons.md
@@ -83,7 +83,9 @@ If you have multiple icons and need to sort them, it's recommended you prefix th
 <link rel="icon" type="image/png" href="/3.icon.png" sizes="360x360" />
 ```
 
-**Dark / light mode:** You can also provide dark and light mode icons by appending `-dark`,`-light`, `.dark` or `.light` to the icon name.
+**Dark / light mode:** Append `-dark`, `-light`, `.dark` or `.light` to
+provide both icon variants.
+For example, use `favicon-dark.svg` and `favicon-light.svg`.
 
 **Example:** Place `icon-dark.png` and `icon-light.png` in `public/` and the module automatically generates:
 
@@ -91,6 +93,11 @@ If you have multiple icons and need to sort them, it's recommended you prefix th
 <link rel="icon" type="image/png" href="/icon-dark.png" sizes="32x32" media="(prefers-color-scheme: dark)" />
 <link rel="icon" type="image/png" href="/icon-light.png" sizes="32x32" media="(prefers-color-scheme: light)" />
 ```
+
+If the app uses `@nuxtjs/color-mode`, the module updates a complete pair when
+the app color mode changes.
+This works when Nuxt UI installs the color mode module.
+Without this module, the browser uses the `prefers-color-scheme` media query.
 
 ### `apple-touch-icon`
 

--- a/src/build-time/iconAssets.test.ts
+++ b/src/build-time/iconAssets.test.ts
@@ -5,7 +5,7 @@ import { createResolver } from '@nuxt/kit'
 import imageSize from 'image-size'
 import { describe, expect, it } from 'vitest'
 import generateTagsFromPublicFiles from './generateTagsFromPublicFiles'
-import { classifyIconFilename, getIconRel, pngToIco } from './iconAssets'
+import { classifyIconFilename, getIconRel, partitionColorModeIconLinks, pngToIco } from './iconAssets'
 
 const { resolve } = createResolver(import.meta.url)
 
@@ -22,6 +22,8 @@ describe('icon asset conventions', () => {
   it.each([
     ['favicon.ico', 'icon'],
     ['favicon.svg', 'icon'],
+    ['favicon-dark.svg', 'icon'],
+    ['favicon.light.png', 'icon'],
     ['icon.ico', 'icon'],
     ['icon.dark.png', 'icon'],
     ['icon-dark.png', 'icon'],
@@ -38,6 +40,44 @@ describe('icon asset conventions', () => {
 
   it('ignores unrelated image files', () => {
     expect(classifyIconFilename('article.png')).toBeUndefined()
+  })
+
+  it('extracts complete color mode pairs from static icon links', () => {
+    const result = partitionColorModeIconLinks([
+      { rel: 'icon', href: '/favicon-dark.svg', media: '(prefers-color-scheme: dark)' },
+      { rel: 'icon', href: '/favicon-light.svg', media: '(prefers-color-scheme: light)' },
+      { rel: 'apple-touch-icon', href: '/touch-dark.png', media: '(prefers-color-scheme: dark)' },
+      { rel: 'apple-touch-icon', href: '/touch-light.png', media: '(prefers-color-scheme: light)' },
+      { rel: 'icon', href: '/fallback.ico' },
+    ])
+
+    expect(result).toEqual({
+      _tag: 'ReactiveIconLinks',
+      links: [
+        { rel: 'icon', href: '/fallback.ico' },
+      ],
+      icons: {
+        dark: [
+          { rel: 'icon', href: '/favicon-dark.svg' },
+          { rel: 'apple-touch-icon', href: '/touch-dark.png' },
+        ],
+        light: [
+          { rel: 'icon', href: '/favicon-light.svg' },
+          { rel: 'apple-touch-icon', href: '/touch-light.png' },
+        ],
+      },
+    })
+  })
+
+  it('keeps incomplete color mode pairs as media links', () => {
+    const links: Link[] = [
+      { rel: 'icon', href: '/favicon-dark.svg', media: '(prefers-color-scheme: dark)' },
+    ]
+
+    expect(partitionColorModeIconLinks(links)).toEqual({
+      _tag: 'StaticIconLinks',
+      links,
+    })
   })
 
   it('writes every supplied PNG size into the ICO directory', () => {

--- a/src/build-time/iconAssets.ts
+++ b/src/build-time/iconAssets.ts
@@ -1,6 +1,12 @@
+import type { Link } from '@unhead/vue/types'
+import type { ColorModeIconLinks } from '../runtime/types'
 import { Buffer } from 'node:buffer'
 
 export type IconRel = 'icon' | 'apple-touch-icon'
+
+export type ResolvedColorModeIconLinks
+  = | { _tag: 'StaticIconLinks', links: Link[] }
+    | { _tag: 'ReactiveIconLinks', links: Link[], icons: ColorModeIconLinks }
 
 export type IconDiagnostic
   = | {
@@ -22,8 +28,9 @@ export interface IcoPng {
 }
 
 const APPLE_ICON_RE = /^(?:[^.]+\.)?apple-(?:icon|touch(?:-icon)?)(?:[.-][^.]+)?\.(?:jpe?g|png)$/i
-const ICON_RE = /^(?:favicon\.(?:ico|png|svg)|(?:[^.]+\.)?icon(?:[.-][^.]+)?\.(?:ico|jpe?g|png|svg))$/i
+const ICON_RE = /^(?:favicon(?:[.-][^.]+)?\.(?:ico|jpe?g|png|svg)|(?:[^.]+\.)?icon(?:[.-][^.]+)?\.(?:ico|jpe?g|png|svg))$/i
 const SIZE_RE = /^\d+x\d+$/
+const COLOR_SCHEME_MEDIA_RE = /^\(\s*prefers-color-scheme\s*:\s*(dark|light)\s*\)$/i
 
 export function classifyIconFilename(filename: string): IconRel | undefined {
   if (APPLE_ICON_RE.test(filename))
@@ -40,6 +47,50 @@ export function getIconRel(rel: unknown): IconRel | undefined {
     return 'apple-touch-icon'
   if (tokens.includes('icon'))
     return 'icon'
+}
+
+function getIconColorMode(media: unknown): keyof ColorModeIconLinks | undefined {
+  if (typeof media !== 'string')
+    return
+  return COLOR_SCHEME_MEDIA_RE.exec(media.trim())?.[1]?.toLowerCase() as keyof ColorModeIconLinks | undefined
+}
+
+export function partitionColorModeIconLinks(links: Link[]): ResolvedColorModeIconLinks {
+  const candidates = links.map((link, index) => {
+    const iconLink = link as Link & { media?: string }
+    return {
+      index,
+      link: iconLink,
+      mode: getIconColorMode(iconLink.media),
+      rel: getIconRel(iconLink.rel),
+    }
+  })
+  const reactiveRels = new Set<IconRel>()
+
+  for (const rel of ['icon', 'apple-touch-icon'] as const) {
+    const modes = new Set(candidates.filter(candidate => candidate.rel === rel).map(candidate => candidate.mode))
+    if (modes.has('dark') && modes.has('light'))
+      reactiveRels.add(rel)
+  }
+
+  if (reactiveRels.size === 0)
+    return { _tag: 'StaticIconLinks', links }
+
+  const icons: ColorModeIconLinks = { dark: [], light: [] }
+  const reactiveIndexes = new Set<number>()
+  for (const candidate of candidates) {
+    if (!candidate.rel || !candidate.mode || !reactiveRels.has(candidate.rel))
+      continue
+    const { media: _, ...link } = candidate.link
+    icons[candidate.mode].push(link as Link)
+    reactiveIndexes.add(candidate.index)
+  }
+
+  return {
+    _tag: 'ReactiveIconLinks',
+    links: links.filter((_, index) => !reactiveIndexes.has(index)),
+    icons,
+  }
 }
 
 export function normalizeIconSizes(configured: unknown, resolved: string): {

--- a/src/const.ts
+++ b/src/const.ts
@@ -2,7 +2,7 @@ import { classifyIconFilename } from './build-time/iconAssets'
 
 export const MetaTagFileDeepGlobs = [
   '**/{og-image,opengraph-image,twitter-image}.{png,jpg,jpeg,gif}',
-  '**/{favicon,icon*}.{ico,jpg,jpeg,png,svg}',
+  '**/{favicon*,icon*}.{ico,jpg,jpeg,png,svg}',
   '**/*.icon*.{ico,jpg,jpeg,png,svg}',
   '**/apple-*.{jpg,jpeg,png}',
   '**/*.apple-*.{jpg,jpeg,png}',

--- a/src/module.ts
+++ b/src/module.ts
@@ -23,6 +23,7 @@ import extendNuxtConfigAppHeadSeoMeta from './build-time/extendNuxtConfigAppHead
 import extendNuxtConfigAppHeadTypes from './build-time/extendNuxtConfigAppHeadTypes'
 import generateTagsFromPageDirImages from './build-time/generateTagsFromPageDirImages'
 import generateTagsFromPublicFiles from './build-time/generateTagsFromPublicFiles'
+import { partitionColorModeIconLinks } from './build-time/iconAssets'
 import minifyStaticHead from './build-time/minifyStaticHead'
 import { resolveUnheadVitePluginSource } from './build-time/resolveUnheadVitePluginSource'
 import setupNuxtConfigAppHeadWithMoreDefaults from './build-time/setupNuxtConfigAppHeadWithMoreDefaults'
@@ -390,6 +391,20 @@ export {}
     })
 
     const appRuntimeDir = resolve(runtimeDir, './app')
+    nuxt.hook('modules:done', () => {
+      if (!hasNuxtModule('@nuxtjs/color-mode', nuxt))
+        return
+
+      const headConfig = nuxt.options.app.head as Record<string, any>
+      const result = partitionColorModeIconLinks(headConfig.link || [])
+      if (result._tag === 'StaticIconLinks')
+        return
+
+      headConfig.link = result.links
+      const seoRuntimeConfig = nuxt.options.runtimeConfig.public['seo-utils'] as Record<string, unknown>
+      seoRuntimeConfig.colorModeIcons = result.icons
+      addPlugin({ src: resolve(appRuntimeDir, 'plugins', 'colorModeIcons') })
+    })
     // Seed nuxt.options.unhead.vite so Nuxt >=4.5.0 compat>=5 (which registers
     // @unhead/vue/vite itself) uses the same config as our fallback registration.
     // Users can pass false to disable the plugin entirely, or override any option.

--- a/src/runtime/app/logic/colorModeIcons.ts
+++ b/src/runtime/app/logic/colorModeIcons.ts
@@ -1,0 +1,14 @@
+import type { Link } from '@unhead/vue/types'
+import type { ColorModeIconLinks } from '../../types'
+
+export function selectColorModeIconLinks(icons: ColorModeIconLinks, colorMode: string): Link[] {
+  const selected = colorMode === 'dark' ? icons.dark : icons.light
+  return selected.map((link, index) => ({
+    ...link,
+    key: `nuxt-seo-utils:color-mode-icon:${getLinkKey(link, index)}`,
+  }))
+}
+
+function getLinkKey(link: Link, index: number): string {
+  return `${link.rel}:${index}`
+}

--- a/src/runtime/app/plugins/colorModeIcons.ts
+++ b/src/runtime/app/plugins/colorModeIcons.ts
@@ -1,0 +1,24 @@
+import type { ColorModeIconLinks } from '../../types'
+import { defineNuxtPlugin, useHead, useNuxtApp, useRuntimeConfig } from '#imports'
+import { selectColorModeIconLinks } from '../logic/colorModeIcons'
+
+interface ColorModeState {
+  value: string
+}
+
+export default defineNuxtPlugin({
+  name: 'nuxt-seo-utils:color-mode-icons',
+  enforce: 'post',
+  setup() {
+    const runtimeConfig = useRuntimeConfig()
+    const seoConfig = runtimeConfig.public['seo-utils'] as { colorModeIcons?: ColorModeIconLinks }
+    const colorMode = useNuxtApp().$colorMode as ColorModeState | undefined
+    const icons = seoConfig.colorModeIcons
+    if (!icons || !colorMode)
+      return
+
+    useHead(() => ({
+      link: selectColorModeIconLinks(icons, colorMode.value),
+    }))
+  },
+})

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,4 +1,9 @@
-import type { Head, MetaFlat, RawInput } from '@unhead/vue/types'
+import type { Head, Link, MetaFlat, RawInput } from '@unhead/vue/types'
+
+export interface ColorModeIconLinks {
+  dark: Link[]
+  light: Link[]
+}
 
 export type MetaFlatSerializable = MetaFlat & {
   title?: RawInput<'title'>

--- a/test/e2e/colorModeIcons.test.ts
+++ b/test/e2e/colorModeIcons.test.ts
@@ -1,22 +1,23 @@
 import { createResolver } from '@nuxt/kit'
-import { createPage, setup } from '@nuxt/test-utils/e2e'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { load } from 'cheerio'
 import { describe, expect, it } from 'vitest'
 
 const { resolve } = createResolver(import.meta.url)
 
 await setup({
-  browser: true,
   dev: true,
   rootDir: resolve('../fixtures/color-mode'),
 })
 
 describe('color mode icons', () => {
-  it('switches the favicon when the app color mode changes', async () => {
-    const page = await createPage('/')
-    const favicon = page.locator('head link[rel="icon"]')
+  it('renders the icon selected by the app color mode', async () => {
+    const html = await $fetch<string>('/')
+    const $ = load(html)
+    const icons = $('head link[rel="icon"]')
 
-    await expect.poll(() => favicon.getAttribute('href')).toBe('/favicon-light.svg')
-    await page.locator('#toggle-color-mode').click()
-    await expect.poll(() => favicon.getAttribute('href')).toBe('/favicon-dark.svg')
+    expect(icons).toHaveLength(1)
+    expect(icons.attr('href')).toBe('/favicon-light.svg')
+    expect(icons.attr('media')).toBeUndefined()
   }, 30_000)
 })

--- a/test/e2e/colorModeIcons.test.ts
+++ b/test/e2e/colorModeIcons.test.ts
@@ -1,0 +1,22 @@
+import { createResolver } from '@nuxt/kit'
+import { createPage, setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  browser: true,
+  dev: true,
+  rootDir: resolve('../fixtures/color-mode'),
+})
+
+describe('color mode icons', () => {
+  it('switches the favicon when the app color mode changes', async () => {
+    const page = await createPage('/')
+    const favicon = page.locator('head link[rel="icon"]')
+
+    await expect.poll(() => favicon.getAttribute('href')).toBe('/favicon-light.svg')
+    await page.locator('#toggle-color-mode').click()
+    await expect.poll(() => favicon.getAttribute('href')).toBe('/favicon-dark.svg')
+  }, 30_000)
+})

--- a/test/fixtures/color-mode/app.vue
+++ b/test/fixtures/color-mode/app.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { useColorMode } from '#imports'
+
+const colorMode = useColorMode()
+
+function toggleColorMode() {
+  colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark'
+}
+</script>
+
+<template>
+  <button id="toggle-color-mode" type="button" @click="toggleColorMode">
+    Toggle color mode
+  </button>
+</template>

--- a/test/fixtures/color-mode/nuxt.config.ts
+++ b/test/fixtures/color-mode/nuxt.config.ts
@@ -1,0 +1,16 @@
+import NuxtSeoUtils from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [
+    NuxtSeoUtils,
+    '@nuxt/ui',
+  ],
+  colorMode: {
+    fallback: 'light',
+    preference: 'light',
+  },
+  seo: {
+    treeShakeUseSeoMeta: false,
+  },
+  compatibilityDate: '2024-08-07',
+})

--- a/test/fixtures/color-mode/public/favicon-dark.svg
+++ b/test/fixtures/color-mode/public/favicon-dark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#fff" />
+</svg>

--- a/test/fixtures/color-mode/public/favicon-light.svg
+++ b/test/fixtures/color-mode/public/favicon-light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#000" />
+</svg>

--- a/test/unit/colorModeIcons.test.ts
+++ b/test/unit/colorModeIcons.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
 
 describe('color mode icon plugin', () => {
   it('updates its head input when the app color mode changes', async () => {
-    const plugin = (await pluginModule).default as { setup: () => void }
+    const plugin = (await pluginModule).default as unknown as { setup: () => void }
     plugin.setup()
     const resolveHead = state.useHead.mock.calls[0]![0] as () => { link: Array<{ href: string }> }
 

--- a/test/unit/colorModeIcons.test.ts
+++ b/test/unit/colorModeIcons.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  colorMode: { value: 'light' },
+  icons: {
+    dark: [{ rel: 'icon', href: '/favicon-dark.svg' }],
+    light: [{ rel: 'icon', href: '/favicon-light.svg' }],
+  },
+  useHead: vi.fn(),
+}))
+
+vi.mock('#imports', () => ({
+  defineNuxtPlugin: (plugin: unknown) => plugin,
+  useHead: state.useHead,
+  useNuxtApp: () => ({ $colorMode: state.colorMode }),
+  useRuntimeConfig: () => ({
+    public: {
+      'seo-utils': {
+        colorModeIcons: state.icons,
+      },
+    },
+  }),
+}))
+
+const pluginModule = import('../../src/runtime/app/plugins/colorModeIcons')
+
+beforeEach(() => {
+  state.colorMode.value = 'light'
+  state.useHead.mockReset()
+})
+
+describe('color mode icon plugin', () => {
+  it('updates its head input when the app color mode changes', async () => {
+    const plugin = (await pluginModule).default as { setup: () => void }
+    plugin.setup()
+    const resolveHead = state.useHead.mock.calls[0]![0] as () => { link: Array<{ href: string }> }
+
+    expect(resolveHead().link[0]?.href).toBe('/favicon-light.svg')
+    state.colorMode.value = 'dark'
+    expect(resolveHead().link[0]?.href).toBe('/favicon-dark.svg')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #131.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Apps can override the operating system color mode, but media-query icons only follow system settings. This adds a runtime plugin for complete dark and light pairs when `@nuxtjs/color-mode` is installed.

The plugin switches regular and Apple touch icons when `colorMode.value` changes. Incomplete pairs keep their media queries. `favicon-dark.*` and `favicon-light.*` now use the same file convention as `icon-dark.*` and `icon-light.*`.
