### PR TITLE
fix: replace vulnerable image parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,11 +89,11 @@
     "defu": "catalog:",
     "escape-string-regexp": "catalog:",
     "exsolve": "catalog:",
-    "image-size": "catalog:",
     "nuxt-site-config": "catalog:",
     "nuxtseo-shared": "catalog:",
     "pathe": "catalog:",
     "pkg-types": "catalog:",
+    "probe-image-size": "catalog:",
     "scule": "catalog:",
     "tinyglobby": "catalog:",
     "ufo": "catalog:"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "nuxtseo-shared": "catalog:",
     "pathe": "catalog:",
     "pkg-types": "catalog:",
-    "probe-image-size": "catalog:",
     "scule": "catalog:",
     "tinyglobby": "catalog:",
     "ufo": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,6 @@ catalogs:
     happy-dom:
       specifier: ^20.11.2
       version: 20.11.2
-    image-size:
-      specifier: ^2.0.2
-      version: 2.0.2
     lint-staged:
       specifier: ^17.3.0
       version: 17.3.0
@@ -102,6 +99,9 @@ catalogs:
     playwright-core:
       specifier: ^1.62.1
       version: 1.62.1
+    probe-image-size:
+      specifier: ^7.3.0
+      version: 7.3.0
     sass:
       specifier: ^1.102.0
       version: 1.102.0
@@ -164,9 +164,6 @@ importers:
       exsolve:
         specifier: 'catalog:'
         version: 1.1.1
-      image-size:
-        specifier: 'catalog:'
-        version: 2.0.2
       lightningcss:
         specifier: '>=1.20.0'
         version: 1.32.0
@@ -182,6 +179,9 @@ importers:
       pkg-types:
         specifier: 'catalog:'
         version: 2.3.1
+      probe-image-size:
+        specifier: 'catalog:'
+        version: 7.3.0(supports-color@10.2.2)
       rolldown:
         specifier: '>=1.0.0-beta.0'
         version: 1.2.0
@@ -3686,14 +3686,8 @@ packages:
     peerDependencies:
       vue: ^3.5.41
 
-  '@vue/devtools-kit@8.1.5':
-    resolution: {integrity: sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==}
-
   '@vue/devtools-kit@8.2.1':
     resolution: {integrity: sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==}
-
-  '@vue/devtools-shared@8.1.5':
-    resolution: {integrity: sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==}
 
   '@vue/devtools-shared@8.2.1':
     resolution: {integrity: sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==}
@@ -4334,6 +4328,22 @@ packages:
       mysql2:
         optional: true
       sqlite3:
+        optional: true
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
         optional: true
 
   debug@4.4.3:
@@ -5145,6 +5155,10 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -5166,11 +5180,6 @@ packages:
 
   image-meta@0.2.2:
     resolution: {integrity: sha512-3MOLanc3sb3LNGWQl1RlQlNWURE5g32aUphrDyFeCsxBTk08iE3VNe4CwsUZ0Qs1X+EfX0+r29Sxdpza4B+yRA==}
-
-  image-size@2.0.2:
-    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
-    engines: {node: '>=16.x'}
-    hasBin: true
 
   immutable@5.1.6:
     resolution: {integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==}
@@ -5601,6 +5610,9 @@ packages:
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
@@ -5911,6 +5923,9 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -5941,6 +5956,11 @@ packages:
   natural-orderby@5.0.0:
     resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
     engines: {node: '>=18'}
+
+  needle@2.9.1:
+    resolution: {integrity: sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==}
+    engines: {node: '>= 4.4.x'}
+    hasBin: true
 
   nitropack@2.13.4:
     resolution: {integrity: sha512-tX7bT6zxNeMwkc6hxHiZeUoTOjVrcjoh1Z3cmxOlodIqjl4HISgqfGOmkWSayky3Nv9Z5+KQH52F8nmXJY5AAA==}
@@ -6641,6 +6661,9 @@ packages:
     resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
     engines: {node: '>=20'}
 
+  probe-image-size@7.3.0:
+    resolution: {integrity: sha512-7CaDeBwiAbh6ohXsvLbAZhO7wzsZAmaevfxe39qvCwRh8LyaZfDlBGGLU1CCTgrTLtCOdwBBhjOrIHaIIimHfQ==}
+
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -7037,6 +7060,9 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  stream-parser@0.3.1:
+    resolution: {integrity: sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==}
 
   streamx@2.27.0:
     resolution: {integrity: sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==}
@@ -9135,7 +9161,7 @@ snapshots:
       srvx: 0.11.22
       std-env: 4.2.0
       tinyclip: 0.1.15
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       ufo: 1.6.4
       youch: 4.1.1
     optionalDependencies:
@@ -11437,7 +11463,7 @@ snapshots:
 
   '@vue-macros/common@3.1.3(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.40
+      '@vue/compiler-sfc': 3.5.41
       ast-kit: 2.2.0
       local-pkg: 1.2.1
       magic-string-ast: 1.0.3
@@ -11521,7 +11547,7 @@ snapshots:
       '@vue/shared': 3.5.41
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.23
+      postcss: 8.5.26
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.40':
@@ -11538,20 +11564,13 @@ snapshots:
 
   '@vue/devtools-api@8.1.5':
     dependencies:
-      '@vue/devtools-kit': 8.1.5
+      '@vue/devtools-kit': 8.2.1
 
   '@vue/devtools-core@8.2.1(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@vue/devtools-kit': 8.2.1
       '@vue/devtools-shared': 8.2.1
       vue: 3.5.41(typescript@6.0.3)
-
-  '@vue/devtools-kit@8.1.5':
-    dependencies:
-      '@vue/devtools-shared': 8.1.5
-      birpc: 2.9.0
-      hookable: 5.5.3
-      perfect-debounce: 2.1.0
 
   '@vue/devtools-kit@8.2.1':
     dependencies:
@@ -11560,15 +11579,13 @@ snapshots:
       hookable: 5.5.3
       perfect-debounce: 2.1.0
 
-  '@vue/devtools-shared@8.1.5': {}
-
   '@vue/devtools-shared@8.2.1': {}
 
   '@vue/language-core@3.3.9':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.40
-      '@vue/shared': 3.5.40
+      '@vue/compiler-dom': 3.5.41
+      '@vue/shared': 3.5.41
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
@@ -11764,13 +11781,13 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.7
+      '@babel/parser': 7.29.8
       pathe: 2.0.3
 
   ast-walker-scope@0.9.0:
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       ast-kit: 2.2.0
 
   async-sema@3.1.1: {}
@@ -12222,6 +12239,18 @@ snapshots:
   csstype@3.2.3: {}
 
   db0@0.3.4: {}
+
+  debug@2.6.9(supports-color@10.2.2):
+    dependencies:
+      ms: 2.0.0
+    optionalDependencies:
+      supports-color: 10.2.2
+
+  debug@3.2.7(supports-color@10.2.2):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -13179,6 +13208,10 @@ snapshots:
 
   human-signals@5.0.0: {}
 
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -13194,8 +13227,6 @@ snapshots:
   ignore@7.0.6: {}
 
   image-meta@0.2.2: {}
-
-  image-size@2.0.2: {}
 
   immutable@5.1.6: {}
 
@@ -13568,6 +13599,8 @@ snapshots:
 
   lodash.memoize@4.1.2: {}
 
+  lodash.merge@4.6.2: {}
+
   lodash.uniq@4.5.0: {}
 
   lodash@4.18.1: {}
@@ -13629,8 +13662,8 @@ snapshots:
 
   magicast@0.5.4:
     dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
       source-map-js: 1.2.1
 
   make-asynchronous@1.1.0:
@@ -14139,6 +14172,8 @@ snapshots:
 
   mrmime@2.0.1: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
@@ -14154,6 +14189,14 @@ snapshots:
   natural-compare@1.4.0: {}
 
   natural-orderby@5.0.0: {}
+
+  needle@2.9.1(supports-color@10.2.2):
+    dependencies:
+      debug: 3.2.7(supports-color@10.2.2)
+      iconv-lite: 0.4.24
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
 
   nitropack@2.13.4(oxc-parser@0.141.0)(rolldown@1.2.0)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
@@ -14676,7 +14719,7 @@ snapshots:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
 
   object-deep-merge@2.0.1: {}
 
@@ -15305,6 +15348,14 @@ snapshots:
 
   pretty-bytes@7.1.0: {}
 
+  probe-image-size@7.3.0(supports-color@10.2.2):
+    dependencies:
+      lodash.merge: 4.6.2
+      needle: 2.9.1(supports-color@10.2.2)
+      stream-parser: 0.3.1(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
@@ -15826,6 +15877,12 @@ snapshots:
 
   std-env@4.2.0: {}
 
+  stream-parser@0.3.1(supports-color@10.2.2):
+    dependencies:
+      debug: 2.6.9(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   streamx@2.27.0:
     dependencies:
       events-universal: 1.0.1
@@ -15976,7 +16033,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,9 +99,6 @@ catalogs:
     playwright-core:
       specifier: ^1.62.1
       version: 1.62.1
-    probe-image-size:
-      specifier: ^7.3.0
-      version: 7.3.0
     sass:
       specifier: ^1.102.0
       version: 1.102.0
@@ -179,9 +176,6 @@ importers:
       pkg-types:
         specifier: 'catalog:'
         version: 2.3.1
-      probe-image-size:
-        specifier: 'catalog:'
-        version: 7.3.0(supports-color@10.2.2)
       rolldown:
         specifier: '>=1.0.0-beta.0'
         version: 1.2.0
@@ -3686,8 +3680,14 @@ packages:
     peerDependencies:
       vue: ^3.5.41
 
+  '@vue/devtools-kit@8.1.5':
+    resolution: {integrity: sha512-FcSAxsi4eWuXLCB7Rv9lj0aIVHHPNVQ2BazGf4RJTc2JCqb4BQg0hk87ZFhminCfl+mD5OUI0rX2cgyu4kJOGA==}
+
   '@vue/devtools-kit@8.2.1':
     resolution: {integrity: sha512-FIGIuq3AWReEpbAHY/cRGeHDfI0qOb8OCQ3YjbEAX04uaxIDbGc9rhkbVcG7rnfHPXE3RsU5KrWOu9V/okd8AQ==}
+
+  '@vue/devtools-shared@8.1.5':
+    resolution: {integrity: sha512-mhT4zcPFhF+Xk1O4BfhhrbXzpmfqY03fS6xGpcllbQG7lDjhQf8pQHcTIhqQIYx1hfwtHmk/6jM96ele0UxPqQ==}
 
   '@vue/devtools-shared@8.2.1':
     resolution: {integrity: sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==}
@@ -4328,22 +4328,6 @@ packages:
       mysql2:
         optional: true
       sqlite3:
-        optional: true
-
-  debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
         optional: true
 
   debug@4.4.3:
@@ -5155,10 +5139,6 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
-  iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -5610,9 +5590,6 @@ packages:
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
-  lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
@@ -5923,9 +5900,6 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
-  ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -5956,11 +5930,6 @@ packages:
   natural-orderby@5.0.0:
     resolution: {integrity: sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg==}
     engines: {node: '>=18'}
-
-  needle@2.9.1:
-    resolution: {integrity: sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==}
-    engines: {node: '>= 4.4.x'}
-    hasBin: true
 
   nitropack@2.13.4:
     resolution: {integrity: sha512-tX7bT6zxNeMwkc6hxHiZeUoTOjVrcjoh1Z3cmxOlodIqjl4HISgqfGOmkWSayky3Nv9Z5+KQH52F8nmXJY5AAA==}
@@ -6661,9 +6630,6 @@ packages:
     resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
     engines: {node: '>=20'}
 
-  probe-image-size@7.3.0:
-    resolution: {integrity: sha512-7CaDeBwiAbh6ohXsvLbAZhO7wzsZAmaevfxe39qvCwRh8LyaZfDlBGGLU1CCTgrTLtCOdwBBhjOrIHaIIimHfQ==}
-
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
@@ -7060,9 +7026,6 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
-
-  stream-parser@0.3.1:
-    resolution: {integrity: sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==}
 
   streamx@2.27.0:
     resolution: {integrity: sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==}
@@ -9161,7 +9124,7 @@ snapshots:
       srvx: 0.11.22
       std-env: 4.2.0
       tinyclip: 0.1.15
-      tinyexec: 1.3.0
+      tinyexec: 1.2.4
       ufo: 1.6.4
       youch: 4.1.1
     optionalDependencies:
@@ -11463,7 +11426,7 @@ snapshots:
 
   '@vue-macros/common@3.1.3(vue@3.5.41(typescript@6.0.3))':
     dependencies:
-      '@vue/compiler-sfc': 3.5.41
+      '@vue/compiler-sfc': 3.5.40
       ast-kit: 2.2.0
       local-pkg: 1.2.1
       magic-string-ast: 1.0.3
@@ -11547,7 +11510,7 @@ snapshots:
       '@vue/shared': 3.5.41
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.26
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.40':
@@ -11564,13 +11527,20 @@ snapshots:
 
   '@vue/devtools-api@8.1.5':
     dependencies:
-      '@vue/devtools-kit': 8.2.1
+      '@vue/devtools-kit': 8.1.5
 
   '@vue/devtools-core@8.2.1(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@vue/devtools-kit': 8.2.1
       '@vue/devtools-shared': 8.2.1
       vue: 3.5.41(typescript@6.0.3)
+
+  '@vue/devtools-kit@8.1.5':
+    dependencies:
+      '@vue/devtools-shared': 8.1.5
+      birpc: 2.9.0
+      hookable: 5.5.3
+      perfect-debounce: 2.1.0
 
   '@vue/devtools-kit@8.2.1':
     dependencies:
@@ -11579,13 +11549,15 @@ snapshots:
       hookable: 5.5.3
       perfect-debounce: 2.1.0
 
+  '@vue/devtools-shared@8.1.5': {}
+
   '@vue/devtools-shared@8.2.1': {}
 
   '@vue/language-core@3.3.9':
     dependencies:
       '@volar/language-core': 2.4.28
-      '@vue/compiler-dom': 3.5.41
-      '@vue/shared': 3.5.41
+      '@vue/compiler-dom': 3.5.40
+      '@vue/shared': 3.5.40
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
@@ -11781,13 +11753,13 @@ snapshots:
 
   ast-kit@2.2.0:
     dependencies:
-      '@babel/parser': 7.29.8
+      '@babel/parser': 7.29.7
       pathe: 2.0.3
 
   ast-walker-scope@0.9.0:
     dependencies:
-      '@babel/parser': 7.29.8
-      '@babel/types': 7.29.8
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       ast-kit: 2.2.0
 
   async-sema@3.1.1: {}
@@ -12239,18 +12211,6 @@ snapshots:
   csstype@3.2.3: {}
 
   db0@0.3.4: {}
-
-  debug@2.6.9(supports-color@10.2.2):
-    dependencies:
-      ms: 2.0.0
-    optionalDependencies:
-      supports-color: 10.2.2
-
-  debug@3.2.7(supports-color@10.2.2):
-    dependencies:
-      ms: 2.1.3
-    optionalDependencies:
-      supports-color: 10.2.2
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -13208,10 +13168,6 @@ snapshots:
 
   human-signals@5.0.0: {}
 
-  iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -13599,8 +13555,6 @@ snapshots:
 
   lodash.memoize@4.1.2: {}
 
-  lodash.merge@4.6.2: {}
-
   lodash.uniq@4.5.0: {}
 
   lodash@4.18.1: {}
@@ -13662,8 +13616,8 @@ snapshots:
 
   magicast@0.5.4:
     dependencies:
-      '@babel/parser': 7.29.8
-      '@babel/types': 7.29.8
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-asynchronous@1.1.0:
@@ -14172,8 +14126,6 @@ snapshots:
 
   mrmime@2.0.1: {}
 
-  ms@2.0.0: {}
-
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
@@ -14189,14 +14141,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   natural-orderby@5.0.0: {}
-
-  needle@2.9.1(supports-color@10.2.2):
-    dependencies:
-      debug: 3.2.7(supports-color@10.2.2)
-      iconv-lite: 0.4.24
-      sax: 1.6.0
-    transitivePeerDependencies:
-      - supports-color
 
   nitropack@2.13.4(oxc-parser@0.141.0)(rolldown@1.2.0)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.102.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
@@ -14719,7 +14663,7 @@ snapshots:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.3.0
+      tinyexec: 1.2.4
 
   object-deep-merge@2.0.1: {}
 
@@ -15348,14 +15292,6 @@ snapshots:
 
   pretty-bytes@7.1.0: {}
 
-  probe-image-size@7.3.0(supports-color@10.2.2):
-    dependencies:
-      lodash.merge: 4.6.2
-      needle: 2.9.1(supports-color@10.2.2)
-      stream-parser: 0.3.1(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
   process-nextick-args@2.0.1: {}
 
   process@0.11.10: {}
@@ -15877,12 +15813,6 @@ snapshots:
 
   std-env@4.2.0: {}
 
-  stream-parser@0.3.1(supports-color@10.2.2):
-    dependencies:
-      debug: 2.6.9(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
   streamx@2.27.0:
     dependencies:
       events-universal: 1.0.1
@@ -16033,7 +15963,7 @@ snapshots:
   terser@5.48.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.18.0
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -98,7 +98,6 @@ catalog:
   pathe: ^2.0.3
   pkg-types: ^2.3.1
   playwright-core: ^1.62.1
-  probe-image-size: ^7.3.0
   sass: ^1.102.0
   scule: ^1.3.0
   sharp: ^0.35.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,7 +88,6 @@ catalog:
   eslint-plugin-harlanzw: ^0.17.1
   exsolve: ^1.1.1
   happy-dom: ^20.11.2
-  image-size: ^2.0.2
   lint-staged: ^17.3.0
   markdownlint-cli: ^0.49.1
   nuxt: ^4.5.2
@@ -99,6 +98,7 @@ catalog:
   pathe: ^2.0.3
   pkg-types: ^2.3.1
   playwright-core: ^1.62.1
+  probe-image-size: ^7.3.0
   sass: ^1.102.0
   scule: ^1.3.0
   sharp: ^0.35.3

--- a/src/build-time/iconAssets.test.ts
+++ b/src/build-time/iconAssets.test.ts
@@ -2,7 +2,7 @@ import type { Nuxt } from '@nuxt/schema'
 import type { Link, SerializableHead } from '@unhead/vue/types'
 import { Buffer } from 'node:buffer'
 import { createResolver } from '@nuxt/kit'
-import imageSize from 'image-size'
+import probeImageSize from 'probe-image-size/sync.js'
 import { describe, expect, it } from 'vitest'
 import generateTagsFromPublicFiles from './generateTagsFromPublicFiles'
 import { classifyIconFilename, getIconRel, partitionColorModeIconLinks, pngToIco } from './iconAssets'
@@ -88,7 +88,7 @@ describe('icon asset conventions', () => {
       { buffer: onePixelPng, width: 48, height: 48 },
     ])
 
-    expect(imageSize(ico).images).toEqual([
+    expect(probeImageSize(ico)?.variants).toEqual([
       expect.objectContaining({ width: 16, height: 16 }),
       expect.objectContaining({ width: 32, height: 32 }),
       expect.objectContaining({ width: 48, height: 48 }),

--- a/src/build-time/iconAssets.test.ts
+++ b/src/build-time/iconAssets.test.ts
@@ -88,11 +88,15 @@ describe('icon asset conventions', () => {
       { buffer: onePixelPng, width: 48, height: 48 },
     ])
 
-    expect(parseImageDimensions(ico)?.images).toEqual([
-      expect.objectContaining({ width: 16, height: 16 }),
-      expect.objectContaining({ width: 32, height: 32 }),
-      expect.objectContaining({ width: 48, height: 48 }),
-    ])
+    expect(parseImageDimensions(ico)).toEqual({
+      width: 48,
+      height: 48,
+      images: [
+        { width: 16, height: 16 },
+        { width: 32, height: 32 },
+        { width: 48, height: 48 },
+      ],
+    })
   })
 })
 

--- a/src/build-time/iconAssets.test.ts
+++ b/src/build-time/iconAssets.test.ts
@@ -2,10 +2,10 @@ import type { Nuxt } from '@nuxt/schema'
 import type { Link, SerializableHead } from '@unhead/vue/types'
 import { Buffer } from 'node:buffer'
 import { createResolver } from '@nuxt/kit'
-import probeImageSize from 'probe-image-size/sync.js'
 import { describe, expect, it } from 'vitest'
 import generateTagsFromPublicFiles from './generateTagsFromPublicFiles'
 import { classifyIconFilename, getIconRel, partitionColorModeIconLinks, pngToIco } from './iconAssets'
+import { parseImageDimensions } from './imageDimensions'
 
 const { resolve } = createResolver(import.meta.url)
 
@@ -88,7 +88,7 @@ describe('icon asset conventions', () => {
       { buffer: onePixelPng, width: 48, height: 48 },
     ])
 
-    expect(probeImageSize(ico)?.variants).toEqual([
+    expect(parseImageDimensions(ico)?.images).toEqual([
       expect.objectContaining({ width: 16, height: 16 }),
       expect.objectContaining({ width: 32, height: 32 }),
       expect.objectContaining({ width: 48, height: 48 }),

--- a/src/build-time/imageDimensions.ts
+++ b/src/build-time/imageDimensions.ts
@@ -1,0 +1,129 @@
+import { Buffer } from 'node:buffer'
+
+export interface ImageDimension {
+  width: number
+  height: number
+}
+
+export interface ImageDimensions extends ImageDimension {
+  images?: ImageDimension[]
+}
+
+const PNG_SIGNATURE = Buffer.from('89504e470d0a1a0a', 'hex')
+const SVG_ROOT_RE = /<svg(?:\s|>)/i
+
+function validDimensions(width: number, height: number): ImageDimensions | undefined {
+  if (width <= 0 || height <= 0)
+    return undefined
+  return { width, height }
+}
+
+function parsePng(buffer: Buffer): ImageDimensions | undefined {
+  if (buffer.length < 24 || !buffer.subarray(0, 8).equals(PNG_SIGNATURE))
+    return undefined
+  return validDimensions(buffer.readUInt32BE(16), buffer.readUInt32BE(20))
+}
+
+function parseGif(buffer: Buffer): ImageDimensions | undefined {
+  if (buffer.length < 10 || !['GIF87a', 'GIF89a'].includes(buffer.toString('ascii', 0, 6)))
+    return undefined
+  return validDimensions(buffer.readUInt16LE(6), buffer.readUInt16LE(8))
+}
+
+function isJpegSizeMarker(marker: number): boolean {
+  return marker >= 0xC0 && marker <= 0xCF && ![0xC4, 0xC8, 0xCC].includes(marker)
+}
+
+function parseJpeg(buffer: Buffer): ImageDimensions | undefined {
+  if (buffer.length < 4 || buffer[0] !== 0xFF || buffer[1] !== 0xD8)
+    return undefined
+
+  let offset = 2
+  while (offset < buffer.length) {
+    while (offset < buffer.length && buffer[offset] !== 0xFF)
+      offset++
+    while (offset < buffer.length && buffer[offset] === 0xFF)
+      offset++
+    if (offset >= buffer.length)
+      return undefined
+
+    const marker = buffer[offset++]!
+    if (marker === 0xD9 || marker === 0xDA)
+      return undefined
+    if ((marker >= 0xD0 && marker <= 0xD7) || marker === 0x01)
+      continue
+    if (offset + 2 > buffer.length)
+      return undefined
+
+    const segmentLength = buffer.readUInt16BE(offset)
+    if (segmentLength < 2 || offset + segmentLength > buffer.length)
+      return undefined
+    if (isJpegSizeMarker(marker) && segmentLength >= 7)
+      return validDimensions(buffer.readUInt16BE(offset + 5), buffer.readUInt16BE(offset + 3))
+    offset += segmentLength
+  }
+  return undefined
+}
+
+function parseIco(buffer: Buffer): ImageDimensions | undefined {
+  if (buffer.length < 6 || buffer.readUInt16LE(0) !== 0 || buffer.readUInt16LE(2) !== 1)
+    return undefined
+
+  const count = buffer.readUInt16LE(4)
+  if (count === 0 || 6 + count * 16 > buffer.length)
+    return undefined
+
+  const images = Array.from({ length: count }, (_, index) => {
+    const offset = 6 + index * 16
+    return {
+      width: buffer[offset] || 256,
+      height: buffer[offset + 1] || 256,
+    }
+  })
+  return { ...images[0]!, images }
+}
+
+function parseSvgLength(root: string, name: string): number | undefined {
+  const value = root.match(new RegExp(`(?:^|\\s)${name}\\s*=\\s*["']([0-9.]+)(?:px)?["']`, 'i'))?.[1]
+  if (!value)
+    return undefined
+  const parsed = Number(value)
+  return parsed > 0 ? parsed : undefined
+}
+
+function parseSvg(buffer: Buffer): ImageDimensions | undefined {
+  const source = buffer.toString('utf8', 0, Math.min(buffer.length, 4096))
+  const rootStart = source.search(SVG_ROOT_RE)
+  const rootEnd = source.indexOf('>', rootStart)
+  if (rootStart < 0 || rootEnd < 0)
+    return undefined
+
+  const root = source.slice(rootStart, rootEnd + 1)
+  const width = parseSvgLength(root, 'width')
+  const height = parseSvgLength(root, 'height')
+  if (width && height)
+    return { width, height }
+
+  const viewBox = root.match(/(?:^|\s)viewBox\s*=\s*["']([^"']+)["']/i)?.[1]
+    ?.trim()
+    .split(/[\s,]+/)
+    .map(Number)
+  if (!viewBox || viewBox.length !== 4)
+    return undefined
+  const viewBoxDimensions = validDimensions(viewBox[2]!, viewBox[3]!)
+  if (!viewBoxDimensions)
+    return undefined
+  if (width)
+    return { width, height: width * viewBoxDimensions.height / viewBoxDimensions.width }
+  if (height)
+    return { width: height * viewBoxDimensions.width / viewBoxDimensions.height, height }
+  return viewBoxDimensions
+}
+
+export function parseImageDimensions(buffer: Buffer): ImageDimensions | undefined {
+  return parsePng(buffer)
+    || parseGif(buffer)
+    || parseJpeg(buffer)
+    || parseIco(buffer)
+    || parseSvg(buffer)
+}

--- a/src/build-time/imageDimensions.ts
+++ b/src/build-time/imageDimensions.ts
@@ -11,15 +11,29 @@ export interface ImageDimensions extends ImageDimension {
 
 const PNG_SIGNATURE = Buffer.from('89504e470d0a1a0a', 'hex')
 const SVG_ROOT_RE = /<svg(?:\s|>)/i
+const SVG_LENGTH_RE = /^((?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?)(cm|em|ex|in|m|mm|pc|pt|px)?$/i
+const SVG_UNIT_PIXELS: Record<string, number> = {
+  cm: 96 / 2.54,
+  em: 16,
+  ex: 8,
+  in: 96,
+  m: 96 / 2.54 * 100,
+  mm: 96 / 2.54 / 10,
+  pc: 96 / 72 / 12,
+  pt: 96 / 72,
+  px: 1,
+}
 
 function validDimensions(width: number, height: number): ImageDimensions | undefined {
-  if (width <= 0 || height <= 0)
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0)
     return undefined
   return { width, height }
 }
 
 function parsePng(buffer: Buffer): ImageDimensions | undefined {
   if (buffer.length < 24 || !buffer.subarray(0, 8).equals(PNG_SIGNATURE))
+    return undefined
+  if (buffer.readUInt32BE(8) !== 13 || buffer.toString('ascii', 12, 16) !== 'IHDR')
     return undefined
   return validDimensions(buffer.readUInt32BE(16), buffer.readUInt32BE(20))
 }
@@ -58,8 +72,14 @@ function parseJpeg(buffer: Buffer): ImageDimensions | undefined {
     const segmentLength = buffer.readUInt16BE(offset)
     if (segmentLength < 2 || offset + segmentLength > buffer.length)
       return undefined
-    if (isJpegSizeMarker(marker) && segmentLength >= 7)
+    if (isJpegSizeMarker(marker)) {
+      if (segmentLength < 11)
+        return undefined
+      const componentCount = buffer[offset + 7]!
+      if (componentCount === 0 || segmentLength !== 8 + componentCount * 3)
+        return undefined
       return validDimensions(buffer.readUInt16BE(offset + 5), buffer.readUInt16BE(offset + 3))
+    }
     offset += segmentLength
   }
   return undefined
@@ -70,25 +90,38 @@ function parseIco(buffer: Buffer): ImageDimensions | undefined {
     return undefined
 
   const count = buffer.readUInt16LE(4)
-  if (count === 0 || 6 + count * 16 > buffer.length)
+  const directoryEnd = 6 + count * 16
+  if (count === 0 || directoryEnd > buffer.length)
     return undefined
 
   const images = Array.from({ length: count }, (_, index) => {
     const offset = 6 + index * 16
+    const payloadSize = buffer.readUInt32LE(offset + 8)
+    const payloadOffset = buffer.readUInt32LE(offset + 12)
+    if (payloadSize === 0 || payloadOffset < directoryEnd || payloadOffset > buffer.length - payloadSize)
+      return undefined
     return {
       width: buffer[offset] || 256,
       height: buffer[offset + 1] || 256,
     }
   })
-  return { ...images[0]!, images }
+  if (images.includes(undefined))
+    return undefined
+  const validImages = images as ImageDimension[]
+  const largestImage = validImages.reduce((largest, image) =>
+    image.width * image.height > largest.width * largest.height ? image : largest)
+  return { ...largestImage, images: validImages }
 }
 
 function parseSvgLength(root: string, name: string): number | undefined {
-  const value = root.match(new RegExp(`(?:^|\\s)${name}\\s*=\\s*["']([0-9.]+)(?:px)?["']`, 'i'))?.[1]
+  const value = root.match(new RegExp(`(?:^|\\s)${name}\\s*=\\s*["']([^"']+)["']`, 'i'))?.[1]?.trim()
   if (!value)
     return undefined
-  const parsed = Number(value)
-  return parsed > 0 ? parsed : undefined
+  const match = SVG_LENGTH_RE.exec(value)
+  if (!match)
+    return undefined
+  const parsed = Number(match[1]) * (SVG_UNIT_PIXELS[match[2]?.toLowerCase() || 'px'] || 1)
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : undefined
 }
 
 function parseSvg(buffer: Buffer): ImageDimensions | undefined {
@@ -108,15 +141,15 @@ function parseSvg(buffer: Buffer): ImageDimensions | undefined {
     ?.trim()
     .split(/[\s,]+/)
     .map(Number)
-  if (!viewBox || viewBox.length !== 4)
+  if (!viewBox || viewBox.length !== 4 || !viewBox.every(value => Number.isFinite(value)))
     return undefined
-  const viewBoxDimensions = validDimensions(viewBox[2]!, viewBox[3]!)
+  const viewBoxDimensions = validDimensions(Math.round(viewBox[2]!), Math.round(viewBox[3]!))
   if (!viewBoxDimensions)
     return undefined
   if (width)
-    return { width, height: width * viewBoxDimensions.height / viewBoxDimensions.width }
+    return { width, height: Math.floor(width * viewBoxDimensions.height / viewBoxDimensions.width) }
   if (height)
-    return { width: height * viewBoxDimensions.width / viewBoxDimensions.height, height }
+    return { width: Math.floor(height * viewBoxDimensions.width / viewBoxDimensions.height), height }
   return viewBoxDimensions
 }
 

--- a/src/shim.d.ts
+++ b/src/shim.d.ts
@@ -27,17 +27,3 @@ declare module 'sharp' {
   const sharp: SharpFactory
   export default sharp
 }
-
-declare module 'probe-image-size/sync.js' {
-  interface ImageVariant {
-    width: number
-    height: number
-  }
-
-  interface ImageDimensions extends ImageVariant {
-    variants?: ImageVariant[]
-  }
-
-  const probeImageSize: (data: Uint8Array) => ImageDimensions | null
-  export default probeImageSize
-}

--- a/src/shim.d.ts
+++ b/src/shim.d.ts
@@ -27,3 +27,17 @@ declare module 'sharp' {
   const sharp: SharpFactory
   export default sharp
 }
+
+declare module 'probe-image-size/sync.js' {
+  interface ImageVariant {
+    width: number
+    height: number
+  }
+
+  interface ImageDimensions extends ImageVariant {
+    variants?: ImageVariant[]
+  }
+
+  const probeImageSize: (data: Uint8Array) => ImageDimensions | null
+  export default probeImageSize
+}

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,0 +1,34 @@
+import { Buffer } from 'node:buffer'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { resolve } from 'pathe'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { getImageDimensions } from './util'
+
+describe('getImageDimensions', () => {
+  let fixtureRoot: string
+
+  beforeAll(async () => {
+    fixtureRoot = await mkdtemp(resolve(tmpdir(), 'nuxt-seo-utils-'))
+  })
+
+  afterAll(async () => {
+    await rm(fixtureRoot, { recursive: true })
+  })
+
+  it.each([
+    [
+      'ICNS',
+      Buffer.from('69636e73000000106973333200000000', 'hex'),
+    ],
+    [
+      'HEIF',
+      Buffer.from('00000010667479706176696600000000000000246d657461000000000000000869707270000000146970636f000000006973706500000000000000000000000000000000', 'hex'),
+    ],
+  ])('rejects the malicious %s infinite loop payload', async (format, payload) => {
+    const path = resolve(fixtureRoot, `malformed-${format.toLowerCase()}`)
+    await writeFile(path, payload)
+
+    await expect(getImageDimensions(path)).rejects.toThrow('Unsupported image format')
+  })
+})

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -21,6 +21,8 @@ describe('getImageDimensions', () => {
     ['GIF', Buffer.from('47494638396103000200', 'hex'), 3, 2],
     ['JPEG', Buffer.from('ffd8ffc0000b080002000301011100', 'hex'), 3, 2],
     ['SVG', Buffer.from('<svg viewBox="0 0 32 24"></svg>'), 32, 24],
+    ['SVG absolute units', Buffer.from('<svg width="2in" height="1in"></svg>'), 192, 96],
+    ['SVG inferred height', Buffer.from('<svg width="100" viewBox="0 0 3 2"></svg>'), 100, 66],
   ])('reads %s dimensions', async (format, payload, width, height) => {
     const path = resolve(fixtureRoot, `valid-${format.toLowerCase()}`)
     await writeFile(path, payload)
@@ -38,10 +40,30 @@ describe('getImageDimensions', () => {
       Buffer.from('00000010667479706176696600000000000000246d657461000000000000000869707270000000146970636f000000006973706500000000000000000000000000000000', 'hex'),
     ],
     [
+      'JXL',
+      Buffer.from('000000004a584c20', 'hex'),
+    ],
+    [
       'JPEG zero-length segment',
       Buffer.from('ffd8ffe00000', 'hex'),
     ],
-  ])('rejects the malicious %s infinite loop payload', async (format, payload) => {
+    [
+      'PNG without an IHDR chunk',
+      Buffer.from('89504e470d0a1a0a0000000d4e4f50450000000300000002', 'hex'),
+    ],
+    [
+      'JPEG without components',
+      Buffer.from('ffd8ffc00008080002000300', 'hex'),
+    ],
+    [
+      'ICO with a missing image payload',
+      Buffer.from('00000100010010100000010020000400000016000000', 'hex'),
+    ],
+    [
+      'SVG with non-finite dimensions',
+      Buffer.from('<svg viewBox="0 0 1e309 24"></svg>'),
+    ],
+  ])('rejects malformed %s input', async (format, payload) => {
     const path = resolve(fixtureRoot, `malformed-${format.toLowerCase()}`)
     await writeFile(path, payload)
 

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -17,6 +17,18 @@ describe('getImageDimensions', () => {
   })
 
   it.each([
+    ['PNG', Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+X8TqNwAAAABJRU5ErkJggg==', 'base64'), 1, 1],
+    ['GIF', Buffer.from('47494638396103000200', 'hex'), 3, 2],
+    ['JPEG', Buffer.from('ffd8ffc0000b080002000301011100', 'hex'), 3, 2],
+    ['SVG', Buffer.from('<svg viewBox="0 0 32 24"></svg>'), 32, 24],
+  ])('reads %s dimensions', async (format, payload, width, height) => {
+    const path = resolve(fixtureRoot, `valid-${format.toLowerCase()}`)
+    await writeFile(path, payload)
+
+    await expect(getImageDimensions(path)).resolves.toMatchObject({ width, height })
+  })
+
+  it.each([
     [
       'ICNS',
       Buffer.from('69636e73000000106973333200000000', 'hex'),
@@ -24,6 +36,10 @@ describe('getImageDimensions', () => {
     [
       'HEIF',
       Buffer.from('00000010667479706176696600000000000000246d657461000000000000000869707270000000146970636f000000006973706500000000000000000000000000000000', 'hex'),
+    ],
+    [
+      'JPEG zero-length segment',
+      Buffer.from('ffd8ffe00000', 'hex'),
     ],
   ])('rejects the malicious %s infinite loop payload', async (format, payload) => {
     const path = resolve(fixtureRoot, `malformed-${format.toLowerCase()}`)

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,7 @@ import type { SerializableHead } from '@unhead/vue/types'
 import fs from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { dirname, resolve } from 'pathe'
-import probeImageSize from 'probe-image-size/sync.js'
+import { parseImageDimensions } from './build-time/imageDimensions'
 
 export function hasMetaProperty(input: SerializableHead, property: string): boolean | undefined {
   return input.meta?.some(meta => meta.property === property)
@@ -57,12 +57,12 @@ export async function getImageMeta(base: string, path: string, isIcon = false): 
 }
 export async function getImageDimensions(absolutePath: string) {
   const buffer = await readFile(absolutePath)
-  const dimensions = probeImageSize(buffer)
+  const dimensions = parseImageDimensions(buffer)
   if (!dimensions)
     throw new TypeError(`Unsupported image format: ${absolutePath}`)
   return {
     width: dimensions.width,
     height: dimensions.height,
-    images: dimensions.variants,
+    images: dimensions.images,
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,8 +1,8 @@
 import type { SerializableHead } from '@unhead/vue/types'
 import fs from 'node:fs'
 import { readFile } from 'node:fs/promises'
-import imageSize from 'image-size'
 import { dirname, resolve } from 'pathe'
+import probeImageSize from 'probe-image-size/sync.js'
 
 export function hasMetaProperty(input: SerializableHead, property: string): boolean | undefined {
   return input.meta?.some(meta => meta.property === property)
@@ -56,7 +56,13 @@ export async function getImageMeta(base: string, path: string, isIcon = false): 
   return payload
 }
 export async function getImageDimensions(absolutePath: string) {
-  // read the file into a buffer using fs
   const buffer = await readFile(absolutePath)
-  return imageSize(buffer)
+  const dimensions = probeImageSize(buffer)
+  if (!dimensions)
+    throw new TypeError(`Unsupported image format: ${absolutePath}`)
+  return {
+    width: dimensions.width,
+    height: dimensions.height,
+    images: dimensions.variants,
+  }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

`image-size` 2.0.2 has unpatched infinite-loop advisories for ICNS and HEIF/JXL buffers, and its repository is archived. Parse PNG, JPEG, GIF, ICO, and SVG headers directly. ICNS, HEIF, JXL, and malformed inputs now return a normal parse error.