### PR TITLE
chore: adopt eslint-plugin-harlanzw base config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,22 +2,12 @@ import antfu from '@antfu/eslint-config'
 import harlanzw from 'eslint-plugin-harlanzw'
 
 export default antfu(
-  {
-    ignores: [
-      'CLAUDE.md',
-      '.claude/**',
-      'test/fixtures/**',
-      'playground/**',
-      '**/*.md',
-    ],
-  },
-  ...harlanzw({ link: true, nuxt: true, vue: true }),
-  {
-    files: ['examples/**/package.json'],
-    rules: {
-      'pnpm/json-enforce-catalog': 'off',
-      'pnpm/json-valid-catalog': 'off',
-      'pnpm/json-prefer-workspace-settings': 'off',
-    },
-  },
+  {},
+  ...harlanzw({
+    // markdown here is docs content, handled by `lint:docs`
+    base: { ignores: ['**/*.md'] },
+    link: true,
+    nuxt: true,
+    vue: true,
+  }),
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.18.1
-      version: 0.18.1
+      specifier: ^0.19.0
+      version: 0.19.0
     exsolve:
       specifier: ^1.1.1
       version: 1.1.1
@@ -233,7 +233,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       happy-dom:
         specifier: 'catalog:'
         version: 20.11.2
@@ -4254,8 +4254,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.18.1:
-    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
+  eslint-plugin-harlanzw@0.19.0:
+    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -11837,7 +11837,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.17.1
-      version: 0.17.1
+      specifier: ^0.18.1
+      version: 0.18.1
     exsolve:
       specifier: ^1.1.1
       version: 1.1.1
@@ -233,7 +233,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       happy-dom:
         specifier: 'catalog:'
         version: 20.11.2
@@ -4254,8 +4254,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.17.1:
-    resolution: {integrity: sha512-JTqWyTYDdMGvo5RDQ1ugq8Y2hGhcSL432WZX3ls52Ie5e+L2MncacI5OrArWB6/8pO7pK3qdm+hgiaFVXmmHxw==}
+  eslint-plugin-harlanzw@0.18.1:
+    resolution: {integrity: sha512-w2xMDe3zuGPUDO+8GfGUrvUg447XJHqRi6U+IuH/HgsADRqo8SmC4GsQuxKaXq7YdkLe8eYjTtrGYDt/YwnpHw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -11837,7 +11837,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.18.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.19.0
-      version: 0.19.0
+      specifier: ^0.19.2
+      version: 0.19.2
     exsolve:
       specifier: ^1.1.1
       version: 1.1.1
@@ -233,7 +233,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.2(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       happy-dom:
         specifier: 'catalog:'
         version: 20.11.2
@@ -4254,8 +4254,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.19.0:
-    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
+  eslint-plugin-harlanzw@0.19.2:
+    resolution: {integrity: sha512-aXVG5dupBlq2Nn94ffBcxw6iSK7OoFoPriWQW2RlE2FHP8PiQt2hfOU1AxuYk0GqgNMIL9c3cKwdhw1RgyeRcw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -11837,7 +11837,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.2(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 catalogMode: prefer
 minimumReleaseAgeExclude:
+  - eslint-plugin-harlanzw@0.18.1
   - '@img/sharp-darwin-arm64@0.35.0'
   - '@img/sharp-darwin-x64@0.35.0'
   - '@img/sharp-freebsd-wasm32@0.35.0'
@@ -85,7 +86,7 @@ catalog:
   defu: ^6.1.7
   escape-string-regexp: ^5.0.0
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.17.1
+  eslint-plugin-harlanzw: ^0.18.1
   exsolve: ^1.1.1
   happy-dom: ^20.11.2
   lint-staged: ^17.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 catalogMode: prefer
 minimumReleaseAgeExclude:
-  - eslint-plugin-harlanzw@0.19.0
+  - eslint-plugin-harlanzw@0.19.2
   - '@img/sharp-darwin-arm64@0.35.0'
   - '@img/sharp-darwin-x64@0.35.0'
   - '@img/sharp-freebsd-wasm32@0.35.0'
@@ -86,7 +86,7 @@ catalog:
   defu: ^6.1.7
   escape-string-regexp: ^5.0.0
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.19.0
+  eslint-plugin-harlanzw: ^0.19.2
   exsolve: ^1.1.1
   happy-dom: ^20.11.2
   lint-staged: ^17.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 catalogMode: prefer
 minimumReleaseAgeExclude:
-  - eslint-plugin-harlanzw@0.18.1
+  - eslint-plugin-harlanzw@0.19.0
   - '@img/sharp-darwin-arm64@0.35.0'
   - '@img/sharp-darwin-x64@0.35.0'
   - '@img/sharp-freebsd-wasm32@0.35.0'
@@ -86,7 +86,7 @@ catalog:
   defu: ^6.1.7
   escape-string-regexp: ^5.0.0
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.18.1
+  eslint-plugin-harlanzw: ^0.19.0
   exsolve: ^1.1.1
   happy-dom: ^20.11.2
   lint-staged: ^17.3.0

--- a/test/compat-v2/run.mjs
+++ b/test/compat-v2/run.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- progress output for a standalone CLI script */
 // Runs the Unhead v2 compatibility fixture in an isolated temp directory.
 //
 // The fixture must build + run OUTSIDE the repo tree: nested under the repo, the


### PR DESCRIPTION
### 🔗 Linked issue

Follows harlan-zw/nuxt-seo#619 and harlan-zw/nuxt-schema-org#150.

### ❓ Type of change

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

The override blocks in `eslint.config.mjs` were copy-pasted across the nuxt-seo family. `eslint-plugin-harlanzw` 0.19.2 ships them as `base()`, so this repo's config collapses to 13 lines from 23:

```js
export default antfu(
  {},
  ...harlanzw({
    base: { ignores: ['**/*.md'] },
    link: true,
    nuxt: true,
    vue: true,
  }),
)
```

This repo was ignores-only, no rule disables, so the hand-written `CLAUDE.md` / `.claude` / `test/fixtures` / `playground` list and the `examples/**/package.json` pnpm catalog block are all base now. The `**/*.md` ignore stays inline because markdown here is docs content covered by `lint:docs`, not something base should assume.

Because nothing was disabled before, base's relaxations are all new severity changes. Diffing `eslint --print-config` for `src/module.ts`, `src/util.test.ts`, and `examples/basic/package.json`:

- everywhere: `no-use-before-define`, `ts/no-use-before-define`, `node/prefer-global/process`, `node/prefer-global/buffer`, `ts/explicit-function-return-type` to off
- test files: `no-console`, `ts/no-unsafe-function-type` to off

Linted file set unchanged, 123 files either way. Base's test glob covers `.mjs` where nothing did before, which orphaned the file-level `eslint-disable no-console` in `test/compat-v2/run.mjs`, so that's gone.

`antfu()` takes its options as the first argument, hence the `{}`. Adding `type: 'lib'` would have flipped other lib-mode rules on, so I left it off to keep this a pure refactor. Worth a follow-up if the family should be `lib` across the board.

### Additional context

`harlanzw/prefer-satisfies` is new in 0.18.x and warns twice (`devtools/pages/seo-utils/identity.vue`, `src/build-time/imageDimensions.ts`). Unrelated to base, left alone.

0.19.2 lints `CLAUDE.md` with the prompt rules when the prompt config is on, but the `**/*.md` ignore keeps it out here, so no findings surfaced and no `agentFiles: 'ignore'` was needed.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).



