### PR TITLE
feat: validate the Nuxt config head

### DIFF
--- a/src/build-time/validateAppHead.test.ts
+++ b/src/build-time/validateAppHead.test.ts
@@ -96,6 +96,16 @@ describe('redundant tags', () => {
       { _tag: 'SiteNameMismatch', level: 'warn', head: 'Acme', site: 'Acme Inc' },
     ])
   })
+
+  it('guides to set site.name instead of dropping og:site_name when no site name is set', () => {
+    const diagnostics = validateAppHead({
+      head: { meta: [{ property: 'og:site_name', content: 'Acme' }] },
+      siteConfig: {},
+    })
+    expect(diagnostics.some(d => d._tag === 'RedundantTag')).toBe(false)
+    expect(diagnostics[0]).toMatchObject({ _tag: 'SiteNameMismatch', level: 'warn', head: 'Acme' })
+    expect(formatAppHeadDiagnostic(diagnostics[0]!)).toContain('site.name')
+  })
 })
 
 describe('dead and conflicting tags', () => {
@@ -104,6 +114,18 @@ describe('dead and conflicting tags', () => {
       head: { link: [{ rel: 'canonical', href: 'https://example.com' }] },
     })
     expect(diagnostics[0]).toMatchObject({ _tag: 'GlobalPageTag', level: 'error', tag: 'link[rel="canonical"]' })
+  })
+
+  it('skips module-owned diagnostics when the module defaults are disabled', () => {
+    const head = {
+      meta: [
+        { property: 'og:url', content: 'https://example.com' },
+        { property: 'og:type', content: 'website' },
+      ],
+      link: [{ rel: 'canonical', href: 'https://example.com' }],
+    }
+    expect(validateAppHead({ head, defaultsActive: false })).toEqual([])
+    expect(tags({ head })).toEqual(['GlobalPageTag', 'RedundantTag', 'GlobalPageTag'])
   })
 
   it('flags a global og:url and hreflang', () => {
@@ -144,6 +166,39 @@ describe('dead and conflicting tags', () => {
         ],
       },
     })).toEqual([])
+  })
+
+  it('accepts duplicate arrayable meta keys that unhead renders as a list', () => {
+    expect(validateAppHead({
+      head: {
+        meta: [
+          { property: 'og:image', content: 'https://example.com/a.png' },
+          { property: 'og:image', content: 'https://example.com/b.png' },
+        ],
+      },
+    })).toEqual([])
+  })
+
+  it('accepts a second theme-color, another arrayable key', () => {
+    expect(validateAppHead({
+      head: {
+        meta: [
+          { name: 'theme-color', content: '#000000', media: '(prefers-color-scheme: dark)' },
+          { name: 'theme-color', content: '#ffffff', media: '(prefers-color-scheme: light)' },
+        ],
+      },
+    })).toEqual([])
+  })
+
+  it('still flags duplicates of keys unhead dedupes', () => {
+    expect(tags({
+      head: {
+        meta: [
+          { property: 'og:title', content: 'One' },
+          { property: 'og:title', content: 'Two' },
+        ],
+      },
+    })).toEqual(['DuplicateTag'])
   })
 
   it('flags a meta entry with no identifying key', () => {

--- a/src/build-time/validateAppHead.test.ts
+++ b/src/build-time/validateAppHead.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import { formatAppHeadDiagnostic, validateAppHead } from './validateAppHead'
+
+function tags(input: Parameters<typeof validateAppHead>[0]): string[] {
+  return validateAppHead(input).map(d => d._tag)
+}
+
+describe('locale checks', () => {
+  it('flags a non-english lang when no default locale is set', () => {
+    const diagnostics = validateAppHead({
+      head: { htmlAttrs: { lang: 'fr' } },
+    })
+    expect(diagnostics).toEqual([
+      { _tag: 'LocaleMismatch', level: 'warn', lang: 'fr', defaultLocale: 'en', configured: false },
+    ])
+    expect(formatAppHeadDiagnostic(diagnostics[0]!)).toContain('defaultLocale: \'fr\'')
+  })
+
+  it('flags a lang that disagrees with the configured default locale', () => {
+    expect(validateAppHead({
+      head: { htmlAttrs: { lang: 'de' } },
+      siteConfig: { defaultLocale: 'fr-FR' },
+    })).toEqual([
+      { _tag: 'LocaleMismatch', level: 'warn', lang: 'de', defaultLocale: 'fr-FR', configured: true },
+    ])
+  })
+
+  it('accepts a lang that matches the default locale region', () => {
+    expect(validateAppHead({
+      head: { htmlAttrs: { lang: 'en' } },
+      siteConfig: { defaultLocale: 'en-US' },
+    })).toEqual([])
+  })
+
+  it('flags an underscored html lang', () => {
+    expect(validateAppHead({
+      head: { htmlAttrs: { lang: 'fr_FR' } },
+      siteConfig: { defaultLocale: 'fr-FR' },
+    })).toEqual([
+      { _tag: 'LangNotBcp47', level: 'warn', lang: 'fr_FR', resolved: 'fr-FR' },
+    ])
+  })
+
+  it('flags a hyphenated og:locale', () => {
+    expect(validateAppHead({
+      head: { meta: [{ property: 'og:locale', content: 'fr-FR' }] },
+    })).toEqual([
+      { _tag: 'OgLocaleNotUnderscored', level: 'warn', content: 'fr-FR', resolved: 'fr_FR' },
+    ])
+  })
+
+  it('flags a static lang when i18n is installed instead of a mismatch', () => {
+    expect(validateAppHead({
+      head: { htmlAttrs: { lang: 'fr' } },
+      hasI18n: true,
+    })).toEqual([
+      { _tag: 'StaticLangWithI18n', level: 'warn', lang: 'fr' },
+    ])
+  })
+})
+
+describe('redundant tags', () => {
+  it('flags tags that repeat nuxt and module defaults', () => {
+    expect(tags({
+      head: {
+        charset: 'utf-8',
+        viewport: 'width=device-width, initial-scale=1',
+        meta: [
+          { charset: 'utf-8' },
+          { name: 'viewport', content: 'width=device-width,  initial-scale=1' },
+          { property: 'og:type', content: 'website' },
+          { name: 'robots', content: 'index, follow' },
+        ],
+      },
+    })).toEqual(['RedundantTag', 'RedundantTag', 'RedundantTag', 'RedundantTag', 'RedundantTag', 'RedundantTag'])
+  })
+
+  it('keeps a viewport that differs from the nuxt default', () => {
+    expect(validateAppHead({
+      head: { meta: [{ name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' }] },
+    })).toEqual([])
+  })
+
+  it('flags og:site_name that repeats the site name', () => {
+    expect(tags({
+      head: { meta: [{ property: 'og:site_name', content: 'Acme' }] },
+      siteConfig: { name: 'Acme' },
+    })).toEqual(['RedundantTag'])
+  })
+
+  it('flags og:site_name that disagrees with the site name', () => {
+    expect(validateAppHead({
+      head: { meta: [{ property: 'og:site_name', content: 'Acme' }] },
+      siteConfig: { name: 'Acme Inc' },
+    })).toEqual([
+      { _tag: 'SiteNameMismatch', level: 'warn', head: 'Acme', site: 'Acme Inc' },
+    ])
+  })
+})
+
+describe('dead and conflicting tags', () => {
+  it('flags a global canonical as an error', () => {
+    const diagnostics = validateAppHead({
+      head: { link: [{ rel: 'canonical', href: 'https://example.com' }] },
+    })
+    expect(diagnostics[0]).toMatchObject({ _tag: 'GlobalPageTag', level: 'error', tag: 'link[rel="canonical"]' })
+  })
+
+  it('flags a global og:url and hreflang', () => {
+    expect(tags({
+      head: {
+        meta: [{ property: 'og:url', content: 'https://example.com' }],
+        link: [{ rel: 'alternate', hreflang: 'fr', href: 'https://example.com/fr' }],
+      },
+    })).toEqual(['GlobalPageTag', 'GlobalPageTag'])
+  })
+
+  it('flags a robots tag when the robots module owns it', () => {
+    expect(validateAppHead({
+      head: { meta: [{ name: 'robots', content: 'noindex' }] },
+      hasRobotsModule: true,
+    })).toEqual([
+      { _tag: 'RobotsModuleConflict', level: 'warn', content: 'noindex' },
+    ])
+  })
+
+  it('flags duplicate tags with different content', () => {
+    expect(tags({
+      head: {
+        meta: [
+          { name: 'description', content: 'One' },
+          { name: 'description', content: 'Two' },
+        ],
+      },
+    })).toEqual(['DuplicateTag'])
+  })
+
+  it('ignores duplicate tags with identical content', () => {
+    expect(validateAppHead({
+      head: {
+        meta: [
+          { name: 'description', content: 'One' },
+          { name: 'description', content: 'One' },
+        ],
+      },
+    })).toEqual([])
+  })
+
+  it('flags a meta entry with no identifying key', () => {
+    expect(validateAppHead({
+      head: { meta: [{ content: 'orphaned' }] },
+    })).toEqual([
+      { _tag: 'MalformedTag', level: 'warn', index: 0 },
+    ])
+  })
+
+  it('flags a title template with no page title placeholder', () => {
+    expect(tags({
+      head: { titleTemplate: 'My Site' },
+    })).toEqual(['TitleTemplateMissingPlaceholder'])
+  })
+
+  it('accepts a title template with a placeholder', () => {
+    expect(validateAppHead({ head: { titleTemplate: '%s | My Site' } })).toEqual([])
+  })
+
+  it('flags a relative social image when no site url is set', () => {
+    expect(validateAppHead({
+      head: { meta: [{ property: 'og:image', content: '/og.png' }] },
+    })).toEqual([
+      { _tag: 'RelativeSocialImage', level: 'warn', tag: 'og:image', src: '/og.png' },
+    ])
+  })
+
+  it('accepts a relative social image once a site url is set', () => {
+    expect(validateAppHead({
+      head: { meta: [{ property: 'og:image', content: '/og.png' }] },
+      siteConfig: { url: 'https://example.com' },
+    })).toEqual([])
+  })
+})
+
+describe('clean configs', () => {
+  it('reports nothing for a head with no issues', () => {
+    expect(validateAppHead({
+      head: {
+        titleTemplate: '%s %separator %siteName',
+        htmlAttrs: { lang: 'fr-FR' },
+        meta: [{ name: 'theme-color', content: '#000000' }],
+        link: [{ rel: 'icon', href: '/favicon.ico' }],
+      },
+      siteConfig: { name: 'Acme', url: 'https://example.com', defaultLocale: 'fr-FR' },
+    })).toEqual([])
+  })
+})

--- a/src/build-time/validateAppHead.test.ts
+++ b/src/build-time/validateAppHead.test.ts
@@ -243,7 +243,7 @@ describe('dead and conflicting tags', () => {
     expect(validateAppHead({
       head: { meta: [{ content: 'orphaned' }] },
     })).toEqual([
-      { _tag: 'MalformedTag', level: 'warn', index: 0 },
+      { _tag: 'MalformedTag', level: 'warn', index: 0, layered: false },
     ])
   })
 
@@ -341,6 +341,40 @@ describe('layered heads', () => {
       [{ name: 'description', content: 'Base' }],
       [{ name: 'description', content: 'Project' }],
     ])
+  })
+
+  it('collects app.head.seoMeta, which reaches the head as meta tags', () => {
+    const head = collectUserAppHead({
+      options: {
+        _layers: [
+          { config: { app: { head: { seoMeta: { ogSiteName: 'Project' } } } } },
+        ],
+      },
+    } as unknown as Parameters<typeof collectUserAppHead>[0])
+    expect(head.metaByLayer).toEqual([
+      [{ property: 'og:site_name', content: 'Project' }],
+    ])
+  })
+
+  it('renders a layer seoMeta entry after the meta array of that layer', () => {
+    const head = collectUserAppHead({
+      options: {
+        _layers: [
+          {
+            config: {
+              app: {
+                head: {
+                  meta: [{ property: 'og:site_name', content: 'From meta' }],
+                  seoMeta: { ogSiteName: 'From seoMeta' },
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as Parameters<typeof collectUserAppHead>[0])
+    // extendNuxtConfigAppHeadSeoMeta appends unpacked seoMeta, so it wins the dedupe
+    expect(head.metaByLayer!.at(-1)).toEqual([{ property: 'og:site_name', content: 'From seoMeta' }])
   })
 
   it('keeps the project value for scalars and html attributes', () => {

--- a/src/build-time/validateAppHead.test.ts
+++ b/src/build-time/validateAppHead.test.ts
@@ -96,6 +96,28 @@ describe('redundant tags', () => {
     })).toEqual([])
   })
 
+  it('keeps a sole og:site_name when the module defaults are disabled', () => {
+    const diagnostics = validateAppHead({
+      head: { meta: [{ property: 'og:site_name', content: 'Acme' }] },
+      siteConfig: {},
+      defaultsActive: false,
+    })
+    expect(diagnostics).toEqual([])
+    for (const diagnostic of diagnostics) {
+      const message = formatAppHeadDiagnostic(diagnostic)
+      expect(message).not.toContain('remove the meta tag')
+      expect(message).not.toContain('nuxt-seo-utils then sets it')
+    }
+  })
+
+  it('keeps a disagreeing og:site_name when the module defaults are disabled', () => {
+    expect(validateAppHead({
+      head: { meta: [{ property: 'og:site_name', content: 'Acme' }] },
+      siteConfig: { name: 'Acme Inc' },
+      defaultsActive: false,
+    })).toEqual([])
+  })
+
   it('keeps a description that repeats the site config when site config merging is disabled', () => {
     expect(validateAppHead({
       head: { meta: [{ name: 'description', content: 'Acme builds things.' }] },

--- a/src/build-time/validateAppHead.test.ts
+++ b/src/build-time/validateAppHead.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatAppHeadDiagnostic, validateAppHead } from './validateAppHead'
+import { collectUserAppHead, formatAppHeadDiagnostic, validateAppHead } from './validateAppHead'
 
 function tags(input: Parameters<typeof validateAppHead>[0]): string[] {
   return validateAppHead(input).map(d => d._tag)
@@ -262,5 +262,75 @@ describe('clean configs', () => {
       },
       siteConfig: { name: 'Acme', url: 'https://example.com', defaultLocale: 'fr-FR' },
     })).toEqual([])
+  })
+})
+
+describe('layered heads', () => {
+  it('reads only the entry a later layer does not override', () => {
+    // a base layer sets og:site_name, the project overrides it with the site name
+    expect(validateAppHead({
+      head: {
+        metaByLayer: [
+          [{ property: 'og:site_name', content: 'Acme' }],
+          [{ property: 'og:site_name', content: 'Acme Inc' }],
+        ],
+      },
+      siteConfig: { name: 'Acme Inc' },
+    })).toEqual([
+      { _tag: 'RedundantTag', level: 'info', tag: 'og:site_name', reason: 'nuxt-seo-utils sets it from your site config.' },
+    ])
+  })
+
+  it('accepts a project layer that overrides a base layer tag', () => {
+    expect(validateAppHead({
+      head: {
+        metaByLayer: [
+          [{ name: 'description', content: 'Base description.' }],
+          [{ name: 'description', content: 'Project description.' }],
+        ],
+      },
+    })).toEqual([])
+  })
+
+  it('still flags a tag set twice inside one layer', () => {
+    expect(tags({
+      head: {
+        metaByLayer: [
+          [
+            { name: 'description', content: 'One' },
+            { name: 'description', content: 'Two' },
+          ],
+        ],
+      },
+    })).toEqual(['DuplicateTag'])
+  })
+
+  it('collects layer meta in the order unhead renders it', () => {
+    const head = collectUserAppHead({
+      options: {
+        _layers: [
+          { config: { app: { head: { meta: [{ name: 'description', content: 'Project' }] } } } },
+          { config: { app: { head: { meta: [{ name: 'description', content: 'Base' }] } } } },
+        ],
+      },
+    } as unknown as Parameters<typeof collectUserAppHead>[0])
+    // Nuxt renders base layers first and the project last, so the project wins
+    expect(head.metaByLayer).toEqual([
+      [{ name: 'description', content: 'Base' }],
+      [{ name: 'description', content: 'Project' }],
+    ])
+  })
+
+  it('keeps the project value for scalars and html attributes', () => {
+    const head = collectUserAppHead({
+      options: {
+        _layers: [
+          { config: { app: { head: { titleTemplate: '%s | Project', htmlAttrs: { lang: 'fr' } } } } },
+          { config: { app: { head: { titleTemplate: 'BASE %s', htmlAttrs: { lang: 'de' } } } } },
+        ],
+      },
+    } as unknown as Parameters<typeof collectUserAppHead>[0])
+    expect(head.titleTemplate).toBe('%s | Project')
+    expect(head.htmlAttrs).toEqual({ lang: 'fr' })
   })
 })

--- a/src/build-time/validateAppHead.test.ts
+++ b/src/build-time/validateAppHead.test.ts
@@ -88,6 +88,22 @@ describe('redundant tags', () => {
     })).toEqual(['RedundantTag'])
   })
 
+  it('keeps a matching og:site_name when the module defaults are disabled', () => {
+    expect(validateAppHead({
+      head: { meta: [{ property: 'og:site_name', content: 'Acme' }] },
+      siteConfig: { name: 'Acme' },
+      defaultsActive: false,
+    })).toEqual([])
+  })
+
+  it('keeps a description that repeats the site config when site config merging is disabled', () => {
+    expect(validateAppHead({
+      head: { meta: [{ name: 'description', content: 'Acme builds things.' }] },
+      siteConfig: { description: 'Acme builds things.' },
+      mergeWithSiteConfig: false,
+    })).toEqual([])
+  })
+
   it('flags og:site_name that disagrees with the site name', () => {
     expect(validateAppHead({
       head: { meta: [{ property: 'og:site_name', content: 'Acme' }] },

--- a/src/build-time/validateAppHead.ts
+++ b/src/build-time/validateAppHead.ts
@@ -29,7 +29,7 @@ export interface AppHeadContext {
   /**
    * Whether the module's automatic defaults own the per route tags.
    * When `false`, diagnostics that claim nuxt-seo-utils sets canonical, `og:url`,
-   * or `og:type` are skipped, they would be wrong advice.
+   * `og:type`, or `og:site_name` are skipped, they would be wrong advice.
    */
   defaultsActive?: boolean
   /**
@@ -200,16 +200,17 @@ function checkMeta(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void 
         diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'robots', reason: 'Crawlers index and follow by default.' })
     }
 
-    if (key === 'og:site_name' && content) {
+    // the module only owns `og:site_name` when the automatic defaults are active,
+    // so with them off any user tag is doing real work and must not be flagged
+    if (key === 'og:site_name' && content && ctx.defaultsActive !== false) {
       const siteName = asString(ctx.siteConfig?.name)
       if (!siteName) {
         // no site `name` means the module sets nothing, so the tag is doing real work
         diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content })
       }
       else if (siteName === content) {
-        // the tag already renders the site name, so flag redundancy only when the module owns the tag
-        if (ctx.defaultsActive !== false)
-          diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:site_name', reason: 'nuxt-seo-utils sets it from your site config.' })
+        // the tag already renders the site name, which the module also sets
+        diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:site_name', reason: 'nuxt-seo-utils sets it from your site config.' })
       }
       else {
         diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content, site: siteName })

--- a/src/build-time/validateAppHead.ts
+++ b/src/build-time/validateAppHead.ts
@@ -1,4 +1,5 @@
 import type { Nuxt } from '@nuxt/schema'
+import { unpackMeta } from '@unhead/vue/utils'
 
 /**
  * A head entry as authored in `nuxt.config`. Values stay `unknown` because the user
@@ -9,7 +10,6 @@ export interface HeadEntry { [key: string]: unknown }
 export interface UserAppHead {
   charset?: unknown
   viewport?: unknown
-  title?: unknown
   titleTemplate?: unknown
   htmlAttrs?: Record<string, unknown>
   /** Meta entries authored in one place. Use `metaByLayer` when several layers contribute. */
@@ -53,7 +53,7 @@ export type AppHeadDiagnostic
     | { _tag: 'RedundantTag', level: 'info', tag: string, reason: string }
     | { _tag: 'GlobalPageTag', level: 'error' | 'warn', tag: string, reason: string }
     | { _tag: 'DuplicateTag', level: 'warn', tag: string }
-    | { _tag: 'MalformedTag', level: 'warn', index: number }
+    | { _tag: 'MalformedTag', level: 'warn', index: number, layered: boolean }
     | { _tag: 'TitleTemplateMissingPlaceholder', level: 'warn', titleTemplate: string }
     | { _tag: 'SiteNameMismatch', level: 'warn', head: string, site?: string }
     | { _tag: 'RelativeSocialImage', level: 'warn', tag: string, src: string }
@@ -195,7 +195,7 @@ function checkMeta(ctx: AppHeadContext, groups: HeadEntry[][], diagnostics: AppH
       index++
       const key = metaTagKey(entry)
       if (!key) {
-        diagnostics.push({ _tag: 'MalformedTag', level: 'warn', index })
+        diagnostics.push({ _tag: 'MalformedTag', level: 'warn', index, layered: groups.length > 1 })
         continue
       }
       const content = key === 'charset' ? asString(entry.charset) : metaContent(entry)
@@ -326,7 +326,10 @@ export function formatAppHeadDiagnostic(diagnostic: AppHeadDiagnostic): string {
     case 'DuplicateTag':
       return `\`${diagnostic.tag}\` is set more than once with different content. Only the last value renders.`
     case 'MalformedTag':
-      return `\`app.head.meta[${diagnostic.index}]\` has no \`name\`, \`property\`, \`http-equiv\`, or \`charset\`. It renders an empty tag.`
+      // the index counts every layer's entries, so it names no single file in a layered app
+      return diagnostic.layered
+        ? `An \`app.head.meta\` entry has no \`name\`, \`property\`, \`http-equiv\`, or \`charset\`. It renders an empty tag.`
+        : `\`app.head.meta[${diagnostic.index}]\` has no \`name\`, \`property\`, \`http-equiv\`, or \`charset\`. It renders an empty tag.`
     case 'TitleTemplateMissingPlaceholder':
       return `\`titleTemplate\` is "${diagnostic.titleTemplate}" and has no \`%s\`. Every page renders the same title. Add \`%s\` where the page title belongs.`
     case 'SiteNameMismatch':
@@ -355,6 +358,10 @@ export function collectUserAppHead(nuxt: Nuxt): UserAppHead {
       continue
     if (layerHead.meta?.length)
       head.metaByLayer!.push(layerHead.meta)
+    // `app.head.seoMeta` unpacks into meta after the layer's own entries, so it renders later
+    const seoMeta = (layerHead as { seoMeta?: Record<string, unknown> }).seoMeta
+    if (seoMeta && Object.keys(seoMeta).length)
+      head.metaByLayer!.push(unpackMeta(seoMeta) as HeadEntry[])
     head.link!.push(...(layerHead.link || []))
   }
   for (const layer of layers) {
@@ -364,7 +371,6 @@ export function collectUserAppHead(nuxt: Nuxt): UserAppHead {
     head.charset ??= layerHead.charset
     head.viewport ??= layerHead.viewport
     head.titleTemplate ??= layerHead.titleTemplate
-    head.title ??= layerHead.title
     if (layerHead.htmlAttrs)
       head.htmlAttrs = { ...layerHead.htmlAttrs, ...head.htmlAttrs }
   }

--- a/src/build-time/validateAppHead.ts
+++ b/src/build-time/validateAppHead.ts
@@ -26,6 +26,12 @@ export interface AppHeadContext {
   }
   hasI18n?: boolean
   hasRobotsModule?: boolean
+  /**
+   * Whether the module's automatic defaults own the per route tags.
+   * When `false`, diagnostics that claim nuxt-seo-utils sets canonical, `og:url`,
+   * or `og:type` are skipped, they would be wrong advice.
+   */
+  defaultsActive?: boolean
 }
 
 export type DiagnosticLevel = 'error' | 'warn' | 'info'
@@ -40,7 +46,7 @@ export type AppHeadDiagnostic
     | { _tag: 'DuplicateTag', level: 'warn', tag: string }
     | { _tag: 'MalformedTag', level: 'warn', index: number }
     | { _tag: 'TitleTemplateMissingPlaceholder', level: 'warn', titleTemplate: string }
-    | { _tag: 'SiteNameMismatch', level: 'warn', head: string, site: string }
+    | { _tag: 'SiteNameMismatch', level: 'warn', head: string, site?: string }
     | { _tag: 'RelativeSocialImage', level: 'warn', tag: string, src: string }
     | { _tag: 'RobotsModuleConflict', level: 'warn', content: string }
 
@@ -52,6 +58,38 @@ const ABSOLUTE_SRC_RE = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i
 
 /** `robots` values that repeat the crawler default. */
 const NOOP_ROBOTS = new Set(['index', 'follow', 'all', 'index,follow', 'follow,index'])
+
+/**
+ * Meta keys unhead keeps every entry for, copied from unhead's `MetaTagsArrayable`.
+ */
+const META_TAGS_ARRAYABLE = new Set([
+  'theme-color',
+  'google-site-verification',
+  'author',
+  'og:locale:alternate',
+  'og:image',
+  'og:video',
+  'og:audio',
+  'article:author',
+  'article:tag',
+  'book:author',
+  'book:tag',
+  'twitter:image',
+])
+
+/**
+ * Whether unhead renders every entry for this key, so a repeat is a list and not a clash.
+ * Mirrors unhead's `isMetaArrayDupeKey`, which matches the suffix after the `meta:` prefix.
+ */
+function isMetaArrayable(key: string): boolean {
+  const dedupeKey = `meta:${key}`
+  const suffix = dedupeKey.slice(dedupeKey.indexOf(':') + 1)
+  return META_TAGS_ARRAYABLE.has(suffix)
+    || suffix.startsWith('og:image:')
+    || suffix.startsWith('og:video:')
+    || suffix.startsWith('og:audio:')
+    || suffix.startsWith('twitter:image:')
+}
 
 function normalizeWhitespace(value: string): string {
   return value.trim().replace(WS_RE, ' ')
@@ -133,7 +171,7 @@ function checkMeta(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void 
       return
     }
     const content = key === 'charset' ? asString(entry.charset) : metaContent(entry)
-    if (seen.has(key) && seen.get(key) !== content)
+    if (seen.has(key) && seen.get(key) !== content && !isMetaArrayable(key))
       diagnostics.push({ _tag: 'DuplicateTag', level: 'warn', tag: key })
     seen.set(key, content)
 
@@ -143,10 +181,10 @@ function checkMeta(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void 
     if (key === 'viewport' && content && normalizeWhitespace(content) === NUXT_DEFAULT_VIEWPORT)
       diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'viewport', reason: 'Nuxt sets the same value by default.' })
 
-    if (key === 'og:type' && content === 'website')
+    if (key === 'og:type' && content === 'website' && ctx.defaultsActive !== false)
       diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:type', reason: 'nuxt-seo-utils sets it by default.' })
 
-    if (key === 'og:url')
+    if (key === 'og:url' && ctx.defaultsActive !== false)
       diagnostics.push({ _tag: 'GlobalPageTag', level: 'warn', tag: 'og:url', reason: 'It applies the same URL to every page. nuxt-seo-utils sets it per route.' })
 
     if (key === 'robots' && content) {
@@ -158,10 +196,16 @@ function checkMeta(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void 
 
     if (key === 'og:site_name' && content) {
       const siteName = asString(ctx.siteConfig?.name)
-      if (!siteName || siteName === content)
+      if (!siteName) {
+        // no site `name` means the module sets nothing, so the tag is doing real work
+        diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content })
+      }
+      else if (siteName === content) {
         diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:site_name', reason: 'nuxt-seo-utils sets it from your site config.' })
-      else
+      }
+      else {
         diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content, site: siteName })
+      }
     }
 
     if (key === 'description' && content && content === asString(ctx.siteConfig?.description))
@@ -191,12 +235,14 @@ function checkLinks(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void
   for (const link of ctx.head.link || []) {
     const rel = asString(link.rel)?.toLowerCase()
     if (rel === 'canonical') {
-      diagnostics.push({
-        _tag: 'GlobalPageTag',
-        level: 'error',
-        tag: 'link[rel="canonical"]',
-        reason: 'It points every page at one URL. nuxt-seo-utils sets a canonical per route.',
-      })
+      if (ctx.defaultsActive !== false) {
+        diagnostics.push({
+          _tag: 'GlobalPageTag',
+          level: 'error',
+          tag: 'link[rel="canonical"]',
+          reason: 'It points every page at one URL. nuxt-seo-utils sets a canonical per route.',
+        })
+      }
     }
     else if (rel === 'alternate' && asString(link.hreflang)) {
       diagnostics.push({
@@ -247,7 +293,9 @@ export function formatAppHeadDiagnostic(diagnostic: AppHeadDiagnostic): string {
     case 'TitleTemplateMissingPlaceholder':
       return `\`titleTemplate\` is "${diagnostic.titleTemplate}" and has no \`%s\`. Every page renders the same title. Add \`%s\` where the page title belongs.`
     case 'SiteNameMismatch':
-      return `\`og:site_name\` is "${diagnostic.head}" but site \`name\` is "${diagnostic.site}". Keep one source of truth. Set \`site.name\` and remove the meta tag.`
+      return diagnostic.site
+        ? `\`og:site_name\` is "${diagnostic.head}" but site \`name\` is "${diagnostic.site}". Keep one source of truth. Set \`site.name\` and remove the meta tag.`
+        : `\`og:site_name\` is "${diagnostic.head}" but no site \`name\` is set. Set \`site.name\` to "${diagnostic.head}" and remove the meta tag, nuxt-seo-utils then sets it from your site config.`
     case 'RelativeSocialImage':
       return `\`${diagnostic.tag}\` is "${diagnostic.src}" and no site \`url\` is set. Crawlers need an absolute URL. Set \`site.url\`.`
     case 'RobotsModuleConflict':

--- a/src/build-time/validateAppHead.ts
+++ b/src/build-time/validateAppHead.ts
@@ -1,0 +1,279 @@
+import type { Nuxt } from '@nuxt/schema'
+
+/**
+ * A head entry as authored in `nuxt.config`. Values stay `unknown` because the user
+ * input is untrusted at this point; each check narrows what it needs.
+ */
+export interface HeadEntry { [key: string]: unknown }
+
+export interface UserAppHead {
+  charset?: unknown
+  viewport?: unknown
+  title?: unknown
+  titleTemplate?: unknown
+  htmlAttrs?: Record<string, unknown>
+  meta?: HeadEntry[]
+  link?: HeadEntry[]
+}
+
+export interface AppHeadContext {
+  head: UserAppHead
+  siteConfig?: {
+    name?: string
+    url?: string
+    description?: string
+    defaultLocale?: string
+  }
+  hasI18n?: boolean
+  hasRobotsModule?: boolean
+}
+
+export type DiagnosticLevel = 'error' | 'warn' | 'info'
+
+export type AppHeadDiagnostic
+  = | { _tag: 'LocaleMismatch', level: 'warn', lang: string, defaultLocale: string, configured: boolean }
+    | { _tag: 'LangNotBcp47', level: 'warn', lang: string, resolved: string }
+    | { _tag: 'OgLocaleNotUnderscored', level: 'warn', content: string, resolved: string }
+    | { _tag: 'StaticLangWithI18n', level: 'warn', lang: string }
+    | { _tag: 'RedundantTag', level: 'info', tag: string, reason: string }
+    | { _tag: 'GlobalPageTag', level: 'error' | 'warn', tag: string, reason: string }
+    | { _tag: 'DuplicateTag', level: 'warn', tag: string }
+    | { _tag: 'MalformedTag', level: 'warn', index: number }
+    | { _tag: 'TitleTemplateMissingPlaceholder', level: 'warn', titleTemplate: string }
+    | { _tag: 'SiteNameMismatch', level: 'warn', head: string, site: string }
+    | { _tag: 'RelativeSocialImage', level: 'warn', tag: string, src: string }
+    | { _tag: 'RobotsModuleConflict', level: 'warn', content: string }
+
+const NUXT_DEFAULT_VIEWPORT = 'width=device-width, initial-scale=1'
+const UNDERSCORE_RE = /_/g
+const HYPHEN_RE = /-/g
+const WS_RE = /\s+/g
+const ABSOLUTE_SRC_RE = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i
+
+/** `robots` values that repeat the crawler default. */
+const NOOP_ROBOTS = new Set(['index', 'follow', 'all', 'index,follow', 'follow,index'])
+
+function normalizeWhitespace(value: string): string {
+  return value.trim().replace(WS_RE, ' ')
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+/** The identity of a meta tag, as unhead dedupes it. */
+export function metaTagKey(entry: HeadEntry): string | undefined {
+  if (asString(entry.charset))
+    return 'charset'
+  const key = asString(entry.name) || asString(entry.property) || asString(entry['http-equiv'])
+  return key?.toLowerCase()
+}
+
+function findMeta(meta: HeadEntry[], key: string): HeadEntry | undefined {
+  return meta.find(entry => metaTagKey(entry) === key)
+}
+
+function metaContent(entry: HeadEntry | undefined): string | undefined {
+  return entry ? asString(entry.content) : undefined
+}
+
+/** The base language of a locale, so `en-US` and `en` compare equal. */
+function baseLanguage(locale: string): string {
+  return locale.toLowerCase().replace(UNDERSCORE_RE, '-').split('-')[0]!
+}
+
+function checkLocale(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void {
+  const lang = asString(ctx.head.htmlAttrs?.lang)
+  const meta = ctx.head.meta || []
+  const ogLocale = metaContent(findMeta(meta, 'og:locale'))
+  if (ogLocale && ogLocale.includes('-')) {
+    diagnostics.push({
+      _tag: 'OgLocaleNotUnderscored',
+      level: 'warn',
+      content: ogLocale,
+      resolved: ogLocale.replace(HYPHEN_RE, '_'),
+    })
+  }
+  if (!lang)
+    return
+  if (lang.includes('_')) {
+    diagnostics.push({
+      _tag: 'LangNotBcp47',
+      level: 'warn',
+      lang,
+      resolved: lang.replace(UNDERSCORE_RE, '-'),
+    })
+  }
+  if (ctx.hasI18n) {
+    // i18n owns the lang attribute per route, so a static value pins every locale to one language.
+    diagnostics.push({ _tag: 'StaticLangWithI18n', level: 'warn', lang })
+    return
+  }
+  const configured = asString(ctx.siteConfig?.defaultLocale)
+  // `applyDefaults` falls back to `en` when no default locale is set.
+  const defaultLocale = configured || 'en'
+  if (baseLanguage(lang) !== baseLanguage(defaultLocale)) {
+    diagnostics.push({
+      _tag: 'LocaleMismatch',
+      level: 'warn',
+      lang,
+      defaultLocale,
+      configured: Boolean(configured),
+    })
+  }
+}
+
+function checkMeta(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void {
+  const meta = ctx.head.meta || []
+  const seen = new Map<string, string | undefined>()
+  meta.forEach((entry, index) => {
+    const key = metaTagKey(entry)
+    if (!key) {
+      diagnostics.push({ _tag: 'MalformedTag', level: 'warn', index })
+      return
+    }
+    const content = key === 'charset' ? asString(entry.charset) : metaContent(entry)
+    if (seen.has(key) && seen.get(key) !== content)
+      diagnostics.push({ _tag: 'DuplicateTag', level: 'warn', tag: key })
+    seen.set(key, content)
+
+    if (key === 'charset' && content?.toLowerCase() === 'utf-8')
+      diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'charset', reason: 'Nuxt sets it by default.' })
+
+    if (key === 'viewport' && content && normalizeWhitespace(content) === NUXT_DEFAULT_VIEWPORT)
+      diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'viewport', reason: 'Nuxt sets the same value by default.' })
+
+    if (key === 'og:type' && content === 'website')
+      diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:type', reason: 'nuxt-seo-utils sets it by default.' })
+
+    if (key === 'og:url')
+      diagnostics.push({ _tag: 'GlobalPageTag', level: 'warn', tag: 'og:url', reason: 'It applies the same URL to every page. nuxt-seo-utils sets it per route.' })
+
+    if (key === 'robots' && content) {
+      if (ctx.hasRobotsModule)
+        diagnostics.push({ _tag: 'RobotsModuleConflict', level: 'warn', content })
+      else if (NOOP_ROBOTS.has(content.toLowerCase().replace(WS_RE, '')))
+        diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'robots', reason: 'Crawlers index and follow by default.' })
+    }
+
+    if (key === 'og:site_name' && content) {
+      const siteName = asString(ctx.siteConfig?.name)
+      if (!siteName || siteName === content)
+        diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:site_name', reason: 'nuxt-seo-utils sets it from your site config.' })
+      else
+        diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content, site: siteName })
+    }
+
+    if (key === 'description' && content && content === asString(ctx.siteConfig?.description))
+      diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'description', reason: 'nuxt-seo-utils sets it from your site config.' })
+
+    if ((key === 'og:image' || key === 'twitter:image') && content && !ABSOLUTE_SRC_RE.test(content) && !asString(ctx.siteConfig?.url))
+      diagnostics.push({ _tag: 'RelativeSocialImage', level: 'warn', tag: key, src: content })
+  })
+}
+
+function checkShorthand(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void {
+  const charset = asString(ctx.head.charset)
+  if (charset?.toLowerCase() === 'utf-8')
+    diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'app.head.charset', reason: 'Nuxt sets `utf-8` by default.' })
+
+  const viewport = asString(ctx.head.viewport)
+  if (viewport && normalizeWhitespace(viewport) === NUXT_DEFAULT_VIEWPORT)
+    diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'app.head.viewport', reason: 'Nuxt sets the same value by default.' })
+
+  const titleTemplate = ctx.head.titleTemplate
+  if (typeof titleTemplate === 'string' && !titleTemplate.includes('%s')) {
+    diagnostics.push({ _tag: 'TitleTemplateMissingPlaceholder', level: 'warn', titleTemplate })
+  }
+}
+
+function checkLinks(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void {
+  for (const link of ctx.head.link || []) {
+    const rel = asString(link.rel)?.toLowerCase()
+    if (rel === 'canonical') {
+      diagnostics.push({
+        _tag: 'GlobalPageTag',
+        level: 'error',
+        tag: 'link[rel="canonical"]',
+        reason: 'It points every page at one URL. nuxt-seo-utils sets a canonical per route.',
+      })
+    }
+    else if (rel === 'alternate' && asString(link.hreflang)) {
+      diagnostics.push({
+        _tag: 'GlobalPageTag',
+        level: 'warn',
+        tag: 'link[rel="alternate"][hreflang]',
+        reason: 'It repeats the same alternate URL on every page. Let @nuxtjs/i18n generate it.',
+      })
+    }
+  }
+}
+
+/**
+ * Check a user authored `app.head` for conflicts, redundancy, and dead tags.
+ *
+ * Pure: pass the head as written in `nuxt.config`, never the head Nuxt has already
+ * normalized, or the injected `charset` and `viewport` defaults read as user input.
+ */
+export function validateAppHead(ctx: AppHeadContext): AppHeadDiagnostic[] {
+  const diagnostics: AppHeadDiagnostic[] = []
+  checkLocale(ctx, diagnostics)
+  checkShorthand(ctx, diagnostics)
+  checkMeta(ctx, diagnostics)
+  checkLinks(ctx, diagnostics)
+  return diagnostics
+}
+
+export function formatAppHeadDiagnostic(diagnostic: AppHeadDiagnostic): string {
+  switch (diagnostic._tag) {
+    case 'LocaleMismatch':
+      return diagnostic.configured
+        ? `\`app.head.htmlAttrs.lang\` is "${diagnostic.lang}" but site \`defaultLocale\` is "${diagnostic.defaultLocale}". og:locale, canonical casing, and Schema.org will use "${diagnostic.defaultLocale}". Set \`site.defaultLocale\` to "${diagnostic.lang}".`
+        : `\`app.head.htmlAttrs.lang\` is "${diagnostic.lang}" but no site \`defaultLocale\` is set, so it falls back to "en". og:locale, canonical casing, and Schema.org will use "en". Add \`site: { defaultLocale: '${diagnostic.lang}' }\` to your Nuxt config.`
+    case 'LangNotBcp47':
+      return `\`app.head.htmlAttrs.lang\` is "${diagnostic.lang}". The HTML lang attribute needs a hyphen. Use "${diagnostic.resolved}".`
+    case 'OgLocaleNotUnderscored':
+      return `\`og:locale\` is "${diagnostic.content}". Open Graph needs an underscore. Use "${diagnostic.resolved}".`
+    case 'StaticLangWithI18n':
+      return `\`app.head.htmlAttrs.lang\` is "${diagnostic.lang}" while an i18n module is installed. It pins every locale to one language. Remove it and set the locale in your i18n config.`
+    case 'RedundantTag':
+      return `\`${diagnostic.tag}\` repeats a default. ${diagnostic.reason} You can remove it.`
+    case 'GlobalPageTag':
+      return `\`${diagnostic.tag}\` is set in \`app.head\`. ${diagnostic.reason}`
+    case 'DuplicateTag':
+      return `\`${diagnostic.tag}\` is set more than once with different content. Only the last value renders.`
+    case 'MalformedTag':
+      return `\`app.head.meta[${diagnostic.index}]\` has no \`name\`, \`property\`, \`http-equiv\`, or \`charset\`. It renders an empty tag.`
+    case 'TitleTemplateMissingPlaceholder':
+      return `\`titleTemplate\` is "${diagnostic.titleTemplate}" and has no \`%s\`. Every page renders the same title. Add \`%s\` where the page title belongs.`
+    case 'SiteNameMismatch':
+      return `\`og:site_name\` is "${diagnostic.head}" but site \`name\` is "${diagnostic.site}". Keep one source of truth. Set \`site.name\` and remove the meta tag.`
+    case 'RelativeSocialImage':
+      return `\`${diagnostic.tag}\` is "${diagnostic.src}" and no site \`url\` is set. Crawlers need an absolute URL. Set \`site.url\`.`
+    case 'RobotsModuleConflict':
+      return `\`robots\` is "${diagnostic.content}" in \`app.head\` while @nuxtjs/robots is installed. The two fight over the tag. Configure it through the robots module instead.`
+  }
+}
+
+/**
+ * Merge the `app.head` each layer authored. Nuxt injects `charset` and `viewport`
+ * defaults into the resolved head, so reading the raw layer config keeps those
+ * defaults from looking like user input.
+ */
+export function collectUserAppHead(nuxt: Nuxt): UserAppHead {
+  const head: UserAppHead = { meta: [], link: [] }
+  for (const layer of nuxt.options._layers || []) {
+    const layerHead = (layer.config?.app as { head?: UserAppHead } | undefined)?.head
+    if (!layerHead)
+      continue
+    head.meta!.push(...(layerHead.meta || []))
+    head.link!.push(...(layerHead.link || []))
+    head.charset ??= layerHead.charset
+    head.viewport ??= layerHead.viewport
+    head.titleTemplate ??= layerHead.titleTemplate
+    head.title ??= layerHead.title
+    if (layerHead.htmlAttrs)
+      head.htmlAttrs = { ...layerHead.htmlAttrs, ...head.htmlAttrs }
+  }
+  return head
+}

--- a/src/build-time/validateAppHead.ts
+++ b/src/build-time/validateAppHead.ts
@@ -32,6 +32,12 @@ export interface AppHeadContext {
    * or `og:type` are skipped, they would be wrong advice.
    */
   defaultsActive?: boolean
+  /**
+   * Whether the module merges site config into the head, owning the `description` tag.
+   * When `false`, diagnostics that claim nuxt-seo-utils sets `description` are skipped,
+   * they would be wrong advice.
+   */
+  mergeWithSiteConfig?: boolean
 }
 
 export type DiagnosticLevel = 'error' | 'warn' | 'info'
@@ -201,14 +207,16 @@ function checkMeta(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void 
         diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content })
       }
       else if (siteName === content) {
-        diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:site_name', reason: 'nuxt-seo-utils sets it from your site config.' })
+        // the tag already renders the site name, so flag redundancy only when the module owns the tag
+        if (ctx.defaultsActive !== false)
+          diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:site_name', reason: 'nuxt-seo-utils sets it from your site config.' })
       }
       else {
         diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content, site: siteName })
       }
     }
 
-    if (key === 'description' && content && content === asString(ctx.siteConfig?.description))
+    if (key === 'description' && content && ctx.mergeWithSiteConfig !== false && content === asString(ctx.siteConfig?.description))
       diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'description', reason: 'nuxt-seo-utils sets it from your site config.' })
 
     if ((key === 'og:image' || key === 'twitter:image') && content && !ABSOLUTE_SRC_RE.test(content) && !asString(ctx.siteConfig?.url))

--- a/src/build-time/validateAppHead.ts
+++ b/src/build-time/validateAppHead.ts
@@ -12,7 +12,10 @@ export interface UserAppHead {
   title?: unknown
   titleTemplate?: unknown
   htmlAttrs?: Record<string, unknown>
+  /** Meta entries authored in one place. Use `metaByLayer` when several layers contribute. */
   meta?: HeadEntry[]
+  /** Meta entries per authoring source, in unhead render order: base layers first, the project last. */
+  metaByLayer?: HeadEntry[][]
   link?: HeadEntry[]
 }
 
@@ -126,9 +129,8 @@ function baseLanguage(locale: string): string {
   return locale.toLowerCase().replace(UNDERSCORE_RE, '-').split('-')[0]!
 }
 
-function checkLocale(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void {
+function checkLocale(ctx: AppHeadContext, meta: HeadEntry[], diagnostics: AppHeadDiagnostic[]): void {
   const lang = asString(ctx.head.htmlAttrs?.lang)
-  const meta = ctx.head.meta || []
   const ogLocale = metaContent(findMeta(meta, 'og:locale'))
   if (ogLocale && ogLocale.includes('-')) {
     diagnostics.push({
@@ -167,61 +169,86 @@ function checkLocale(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): voi
   }
 }
 
-function checkMeta(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void {
-  const meta = ctx.head.meta || []
-  const seen = new Map<string, string | undefined>()
-  meta.forEach((entry, index) => {
-    const key = metaTagKey(entry)
-    if (!key) {
-      diagnostics.push({ _tag: 'MalformedTag', level: 'warn', index })
-      return
+/** The index of every entry unhead actually renders, keyed by dedupe key. */
+function renderedIndexes(groups: HeadEntry[][]): Map<string, number> {
+  const rendered = new Map<string, number>()
+  let index = -1
+  for (const group of groups) {
+    for (const entry of group) {
+      index++
+      const key = metaTagKey(entry)
+      // unhead keeps the last entry for a deduped key, so a later one replaces this
+      if (key && !isMetaArrayable(key))
+        rendered.set(key, index)
     }
-    const content = key === 'charset' ? asString(entry.charset) : metaContent(entry)
-    if (seen.has(key) && seen.get(key) !== content && !isMetaArrayable(key))
-      diagnostics.push({ _tag: 'DuplicateTag', level: 'warn', tag: key })
-    seen.set(key, content)
+  }
+  return rendered
+}
 
-    if (key === 'charset' && content?.toLowerCase() === 'utf-8')
-      diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'charset', reason: 'Nuxt sets it by default.' })
+function checkMeta(ctx: AppHeadContext, groups: HeadEntry[][], diagnostics: AppHeadDiagnostic[]): void {
+  const rendered = renderedIndexes(groups)
+  let index = -1
+  for (const group of groups) {
+    // duplicates only mean a mistake inside one layer, across layers they are an override
+    const seen = new Map<string, string | undefined>()
+    for (const entry of group) {
+      index++
+      const key = metaTagKey(entry)
+      if (!key) {
+        diagnostics.push({ _tag: 'MalformedTag', level: 'warn', index })
+        continue
+      }
+      const content = key === 'charset' ? asString(entry.charset) : metaContent(entry)
+      if (seen.has(key) && seen.get(key) !== content && !isMetaArrayable(key))
+        diagnostics.push({ _tag: 'DuplicateTag', level: 'warn', tag: key })
+      seen.set(key, content)
 
-    if (key === 'viewport' && content && normalizeWhitespace(content) === NUXT_DEFAULT_VIEWPORT)
-      diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'viewport', reason: 'Nuxt sets the same value by default.' })
+      // a later layer replaced this entry, so advice about its value would be wrong
+      if (!isMetaArrayable(key) && rendered.get(key) !== index)
+        continue
 
-    if (key === 'og:type' && content === 'website' && ctx.defaultsActive !== false)
-      diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:type', reason: 'nuxt-seo-utils sets it by default.' })
+      if (key === 'charset' && content?.toLowerCase() === 'utf-8')
+        diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'charset', reason: 'Nuxt sets it by default.' })
 
-    if (key === 'og:url' && ctx.defaultsActive !== false)
-      diagnostics.push({ _tag: 'GlobalPageTag', level: 'warn', tag: 'og:url', reason: 'It applies the same URL to every page. nuxt-seo-utils sets it per route.' })
+      if (key === 'viewport' && content && normalizeWhitespace(content) === NUXT_DEFAULT_VIEWPORT)
+        diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'viewport', reason: 'Nuxt sets the same value by default.' })
 
-    if (key === 'robots' && content) {
-      if (ctx.hasRobotsModule)
-        diagnostics.push({ _tag: 'RobotsModuleConflict', level: 'warn', content })
-      else if (NOOP_ROBOTS.has(content.toLowerCase().replace(WS_RE, '')))
-        diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'robots', reason: 'Crawlers index and follow by default.' })
+      if (key === 'og:type' && content === 'website' && ctx.defaultsActive !== false)
+        diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:type', reason: 'nuxt-seo-utils sets it by default.' })
+
+      if (key === 'og:url' && ctx.defaultsActive !== false)
+        diagnostics.push({ _tag: 'GlobalPageTag', level: 'warn', tag: 'og:url', reason: 'It applies the same URL to every page. nuxt-seo-utils sets it per route.' })
+
+      if (key === 'robots' && content) {
+        if (ctx.hasRobotsModule)
+          diagnostics.push({ _tag: 'RobotsModuleConflict', level: 'warn', content })
+        else if (NOOP_ROBOTS.has(content.toLowerCase().replace(WS_RE, '')))
+          diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'robots', reason: 'Crawlers index and follow by default.' })
+      }
+
+      if (key === 'og:site_name' && content) {
+        const siteName = asString(ctx.siteConfig?.name)
+        if (!siteName) {
+          // no site `name` means the module sets nothing, so the tag is doing real work
+          diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content })
+        }
+        else if (siteName === content) {
+          // the tag already renders the site name, so flag redundancy only when the module owns the tag
+          if (ctx.defaultsActive !== false)
+            diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:site_name', reason: 'nuxt-seo-utils sets it from your site config.' })
+        }
+        else {
+          diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content, site: siteName })
+        }
+      }
+
+      if (key === 'description' && content && ctx.mergeWithSiteConfig !== false && content === asString(ctx.siteConfig?.description))
+        diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'description', reason: 'nuxt-seo-utils sets it from your site config.' })
+
+      if ((key === 'og:image' || key === 'twitter:image') && content && !ABSOLUTE_SRC_RE.test(content) && !asString(ctx.siteConfig?.url))
+        diagnostics.push({ _tag: 'RelativeSocialImage', level: 'warn', tag: key, src: content })
     }
-
-    if (key === 'og:site_name' && content) {
-      const siteName = asString(ctx.siteConfig?.name)
-      if (!siteName) {
-        // no site `name` means the module sets nothing, so the tag is doing real work
-        diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content })
-      }
-      else if (siteName === content) {
-        // the tag already renders the site name, so flag redundancy only when the module owns the tag
-        if (ctx.defaultsActive !== false)
-          diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'og:site_name', reason: 'nuxt-seo-utils sets it from your site config.' })
-      }
-      else {
-        diagnostics.push({ _tag: 'SiteNameMismatch', level: 'warn', head: content, site: siteName })
-      }
-    }
-
-    if (key === 'description' && content && ctx.mergeWithSiteConfig !== false && content === asString(ctx.siteConfig?.description))
-      diagnostics.push({ _tag: 'RedundantTag', level: 'info', tag: 'description', reason: 'nuxt-seo-utils sets it from your site config.' })
-
-    if ((key === 'og:image' || key === 'twitter:image') && content && !ABSOLUTE_SRC_RE.test(content) && !asString(ctx.siteConfig?.url))
-      diagnostics.push({ _tag: 'RelativeSocialImage', level: 'warn', tag: key, src: content })
-  })
+  }
 }
 
 function checkShorthand(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void {
@@ -271,9 +298,10 @@ function checkLinks(ctx: AppHeadContext, diagnostics: AppHeadDiagnostic[]): void
  */
 export function validateAppHead(ctx: AppHeadContext): AppHeadDiagnostic[] {
   const diagnostics: AppHeadDiagnostic[] = []
-  checkLocale(ctx, diagnostics)
+  const groups = ctx.head.metaByLayer ?? (ctx.head.meta ? [ctx.head.meta] : [])
+  checkLocale(ctx, groups.flat(), diagnostics)
   checkShorthand(ctx, diagnostics)
-  checkMeta(ctx, diagnostics)
+  checkMeta(ctx, groups, diagnostics)
   checkLinks(ctx, diagnostics)
   return diagnostics
 }
@@ -317,13 +345,21 @@ export function formatAppHeadDiagnostic(diagnostic: AppHeadDiagnostic): string {
  * defaults from looking like user input.
  */
 export function collectUserAppHead(nuxt: Nuxt): UserAppHead {
-  const head: UserAppHead = { meta: [], link: [] }
-  for (const layer of nuxt.options._layers || []) {
+  const head: UserAppHead = { metaByLayer: [], link: [] }
+  const layers = nuxt.options._layers || []
+  // `_layers` runs project first, unhead renders the project last, so walk it backwards
+  for (let i = layers.length - 1; i >= 0; i--) {
+    const layerHead = (layers[i]?.config?.app as { head?: UserAppHead } | undefined)?.head
+    if (!layerHead)
+      continue
+    if (layerHead.meta?.length)
+      head.metaByLayer!.push(layerHead.meta)
+    head.link!.push(...(layerHead.link || []))
+  }
+  for (const layer of layers) {
     const layerHead = (layer.config?.app as { head?: UserAppHead } | undefined)?.head
     if (!layerHead)
       continue
-    head.meta!.push(...(layerHead.meta || []))
-    head.link!.push(...(layerHead.link || []))
     head.charset ??= layerHead.charset
     head.viewport ??= layerHead.viewport
     head.titleTemplate ??= layerHead.titleTemplate

--- a/src/module.ts
+++ b/src/module.ts
@@ -542,7 +542,9 @@ export {}
         try {
           const userHead = collectUserAppHead(nuxt)
           // `seo.meta` is user authored too, so hold it to the same rules
-          userHead.meta!.push(...unpackMeta(config.meta || {}) as Record<string, unknown>[])
+          const seoMeta = unpackMeta(config.meta || {}) as Record<string, unknown>[]
+          if (seoMeta.length)
+            userHead.metaByLayer!.push(seoMeta)
           const siteConfig = useSiteConfig(nuxt)
           // Unhead's own tag rules already cover these tags. Its Vite plugin injects the
           // runtime ValidatePlugin on the client, which validates the resolved head, and

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import type { AppHeadDiagnostic } from './build-time/validateAppHead'
 import type { MetaFlatSerializable } from './runtime/types'
 import { existsSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
@@ -13,9 +14,10 @@ import {
   hasNuxtCompatibility,
   hasNuxtModule,
 } from '@nuxt/kit'
+import { unpackMeta } from '@unhead/vue/utils'
 import { defu } from 'defu'
 import { resolveModulePath } from 'exsolve'
-import { installNuxtSiteConfig } from 'nuxt-site-config/kit'
+import { installNuxtSiteConfig, useSiteConfig } from 'nuxt-site-config/kit'
 import { renderNitroTypeAugmentations, resolveHostUnheadMajor, setupNitroRuntimeCompatibility, useModuleLogger } from 'nuxtseo-shared/kit'
 import { dirname, relative } from 'pathe'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
@@ -27,6 +29,7 @@ import { partitionColorModeIconLinks } from './build-time/iconAssets'
 import minifyStaticHead from './build-time/minifyStaticHead'
 import { resolveUnheadVitePluginSource } from './build-time/resolveUnheadVitePluginSource'
 import setupNuxtConfigAppHeadWithMoreDefaults from './build-time/setupNuxtConfigAppHeadWithMoreDefaults'
+import { collectUserAppHead, formatAppHeadDiagnostic, validateAppHead } from './build-time/validateAppHead'
 import { setupDevToolsUI } from './build/devtools'
 
 export interface ModuleOptions {
@@ -158,6 +161,13 @@ export interface ModuleOptions {
   minify: boolean | { build?: boolean, runtime?: boolean }
 
   /**
+   * Checks the `app.head` in your Nuxt config for conflicts, redundant tags, and dead tags.
+   * Warnings print on dev server start and on build.
+   *
+   * @default true
+   */
+  validateAppHead: boolean
+  /**
    * Enables debug logs and a debug endpoint.
    *
    * @default false
@@ -202,6 +212,7 @@ export default defineNuxtModule<ModuleOptions>({
     setupNuxtConfigAppHeadWithMoreDefaults: true,
     automaticOgAndTwitterTags: true,
     canonicalLowercase: true,
+    validateAppHead: true,
     tagPriority: 'low',
     minify: { build: true, runtime: false },
   },
@@ -523,6 +534,48 @@ export {}
       addServerHandler({
         route: '/__nuxt-seo-utils/debug.json',
         handler: resolve('./runtime/server/routes/__nuxt-seo-utils/debug'),
+      })
+    }
+
+    if (config.validateAppHead) {
+      // run once every module has contributed to the head and site config
+      nuxt.hook('modules:done', () => {
+        const userHead = collectUserAppHead(nuxt)
+        // `seo.meta` is user authored too, so hold it to the same rules
+        userHead.meta!.push(...unpackMeta(config.meta || {}) as Record<string, unknown>[])
+        const siteConfig = useSiteConfig(nuxt)
+        // Unhead's own tag rules already cover these tags. Its Vite plugin injects the
+        // runtime ValidatePlugin on the client, which validates the resolved head, and
+        // `app.head` reaches that head through Nuxt's `useHead` call. So only check what
+        // Unhead cannot see: how the Nuxt config head lines up with site config, i18n,
+        // and the per route tags this module owns.
+        let diagnostics: AppHeadDiagnostic[]
+        try {
+          diagnostics = validateAppHead({
+            head: userHead,
+            siteConfig: {
+              name: siteConfig.name,
+              url: siteConfig.url,
+              description: siteConfig.description,
+              defaultLocale: siteConfig.defaultLocale,
+            },
+            hasI18n,
+            hasRobotsModule: hasNuxtModule('@nuxtjs/robots', nuxt),
+          })
+        }
+        catch (e) {
+          // a check must never fail the build, so report the miss and move on
+          logger.warn(`Skipped the head config check. ${e}`)
+          return
+        }
+        if (!diagnostics.length)
+          return
+        const lines = diagnostics.map(d => `  ${d.level === 'info' ? '·' : '✖'} ${formatAppHeadDiagnostic(d)}`)
+        const message = `Found ${diagnostics.length} issue${diagnostics.length > 1 ? 's' : ''} in your Nuxt config head.\n${lines.join('\n')}\n  Set \`seo: { validateAppHead: false }\` to turn off this check.`
+        if (diagnostics.some(d => d.level !== 'info'))
+          logger.warn(message)
+        else
+          logger.info(message)
       })
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -551,6 +551,10 @@ export {}
         // and the per route tags this module owns.
         let diagnostics: AppHeadDiagnostic[]
         try {
+        // `@nuxtjs/i18n` and `nuxt-i18n-micro` auto-install through optional module
+        // dependencies, so a module match alone is not proof the user uses i18n.
+        // Only treat i18n as present when a user layer actually configures it.
+          const hasUserI18n = hasI18n && (nuxt.options._layers || []).some(layer => Boolean((layer.config as { i18n?: unknown } | undefined)?.i18n))
           diagnostics = validateAppHead({
             head: userHead,
             siteConfig: {
@@ -559,8 +563,9 @@ export {}
               description: siteConfig.description,
               defaultLocale: siteConfig.defaultLocale,
             },
-            hasI18n,
+            hasI18n: hasUserI18n,
             hasRobotsModule: hasNuxtModule('@nuxtjs/robots', nuxt),
+            defaultsActive: config.automaticDefaults,
           })
         }
         catch (e) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,3 @@
-import type { AppHeadDiagnostic } from './build-time/validateAppHead'
 import type { MetaFlatSerializable } from './runtime/types'
 import { existsSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
@@ -540,22 +539,21 @@ export {}
     if (config.validateAppHead) {
       // run once every module has contributed to the head and site config
       nuxt.hook('modules:done', () => {
-        const userHead = collectUserAppHead(nuxt)
-        // `seo.meta` is user authored too, so hold it to the same rules
-        userHead.meta!.push(...unpackMeta(config.meta || {}) as Record<string, unknown>[])
-        const siteConfig = useSiteConfig(nuxt)
-        // Unhead's own tag rules already cover these tags. Its Vite plugin injects the
-        // runtime ValidatePlugin on the client, which validates the resolved head, and
-        // `app.head` reaches that head through Nuxt's `useHead` call. So only check what
-        // Unhead cannot see: how the Nuxt config head lines up with site config, i18n,
-        // and the per route tags this module owns.
-        let diagnostics: AppHeadDiagnostic[]
         try {
-        // `@nuxtjs/i18n` and `nuxt-i18n-micro` auto-install through optional module
-        // dependencies, so a module match alone is not proof the user uses i18n.
-        // Only treat i18n as present when a user layer actually configures it.
+          const userHead = collectUserAppHead(nuxt)
+          // `seo.meta` is user authored too, so hold it to the same rules
+          userHead.meta!.push(...unpackMeta(config.meta || {}) as Record<string, unknown>[])
+          const siteConfig = useSiteConfig(nuxt)
+          // Unhead's own tag rules already cover these tags. Its Vite plugin injects the
+          // runtime ValidatePlugin on the client, which validates the resolved head, and
+          // `app.head` reaches that head through Nuxt's `useHead` call. So only check what
+          // Unhead cannot see: how the Nuxt config head lines up with site config, i18n,
+          // and the per route tags this module owns.
+          // `@nuxtjs/i18n` and `nuxt-i18n-micro` auto-install through optional module
+          // dependencies, so a module match alone is not proof the user uses i18n.
+          // Only treat i18n as present when a user layer actually configures it.
           const hasUserI18n = hasI18n && (nuxt.options._layers || []).some(layer => Boolean((layer.config as { i18n?: unknown } | undefined)?.i18n))
-          diagnostics = validateAppHead({
+          const diagnostics = validateAppHead({
             head: userHead,
             siteConfig: {
               name: siteConfig.name,
@@ -566,21 +564,21 @@ export {}
             hasI18n: hasUserI18n,
             hasRobotsModule: hasNuxtModule('@nuxtjs/robots', nuxt),
             defaultsActive: config.automaticDefaults,
+            mergeWithSiteConfig: config.mergeWithSiteConfig,
           })
+          if (!diagnostics.length)
+            return
+          const lines = diagnostics.map(d => `  ${d.level === 'info' ? '·' : '✖'} ${formatAppHeadDiagnostic(d)}`)
+          const message = `Found ${diagnostics.length} issue${diagnostics.length > 1 ? 's' : ''} in your Nuxt config head.\n${lines.join('\n')}\n  Set \`seo: { validateAppHead: false }\` to turn off this check.`
+          if (diagnostics.some(d => d.level !== 'info'))
+            logger.warn(message)
+          else
+            logger.info(message)
         }
         catch (e) {
           // a check must never fail the build, so report the miss and move on
           logger.warn(`Skipped the head config check. ${e}`)
-          return
         }
-        if (!diagnostics.length)
-          return
-        const lines = diagnostics.map(d => `  ${d.level === 'info' ? '·' : '✖'} ${formatAppHeadDiagnostic(d)}`)
-        const message = `Found ${diagnostics.length} issue${diagnostics.length > 1 ? 's' : ''} in your Nuxt config head.\n${lines.join('\n')}\n  Set \`seo: { validateAppHead: false }\` to turn off this check.`
-        if (diagnostics.some(d => d.level !== 'info'))
-          logger.warn(message)
-        else
-          logger.info(message)
       })
     }
 

--- a/test/e2e/validateAppHeadMalformedMeta.test.ts
+++ b/test/e2e/validateAppHeadMalformedMeta.test.ts
@@ -1,0 +1,33 @@
+import { createResolver } from '@nuxt/kit'
+import { setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+const logs: string[] = []
+for (const stream of [process.stdout, process.stderr]) {
+  const write = stream.write.bind(stream)
+  stream.write = ((chunk: unknown, ...args: unknown[]) => {
+    logs.push(String(chunk))
+    return write(chunk as never, ...(args as never[]))
+  }) as typeof stream.write
+}
+
+await setup({
+  rootDir: resolve('../fixtures/no-i18n'),
+  nuxtConfig: {
+    // @ts-expect-error module config key
+    seo: {
+      extendNuxtConfigAppHeadSeoMeta: false,
+      meta: {
+        'og:image': [undefined],
+      },
+    },
+  },
+})
+
+describe('validateAppHead with malformed seo.meta', () => {
+  it('skips the check instead of failing the build', () => {
+    expect(logs.join('\n')).toContain('Skipped the head config check.')
+  })
+})

--- a/test/e2e/validateAppHeadMalformedMeta.test.ts
+++ b/test/e2e/validateAppHeadMalformedMeta.test.ts
@@ -1,17 +1,20 @@
 import { createResolver } from '@nuxt/kit'
 import { setup } from '@nuxt/test-utils/e2e'
-import { describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 
 const { resolve } = createResolver(import.meta.url)
 
 const logs: string[] = []
-for (const stream of [process.stdout, process.stderr]) {
+const restore = [process.stdout, process.stderr].map((stream) => {
   const write = stream.write.bind(stream)
   stream.write = ((chunk: unknown, ...args: unknown[]) => {
     logs.push(String(chunk))
     return write(chunk as never, ...(args as never[]))
   }) as typeof stream.write
-}
+  return () => {
+    stream.write = write
+  }
+})
 
 await setup({
   rootDir: resolve('../fixtures/no-i18n'),
@@ -25,6 +28,9 @@ await setup({
     },
   },
 })
+
+// setup() builds inside a beforeAll hook, so keep the streams patched until the suite ends
+afterAll(() => restore.forEach(reset => reset()))
 
 describe('validateAppHead with malformed seo.meta', () => {
   it('skips the check instead of failing the build', () => {

--- a/test/e2e/validateAppHeadStaticLang.test.ts
+++ b/test/e2e/validateAppHeadStaticLang.test.ts
@@ -1,21 +1,27 @@
 import { createResolver } from '@nuxt/kit'
 import { setup } from '@nuxt/test-utils/e2e'
-import { describe, expect, it } from 'vitest'
+import { afterAll, describe, expect, it } from 'vitest'
 
 const { resolve } = createResolver(import.meta.url)
 
 const logs: string[] = []
-for (const stream of [process.stdout, process.stderr]) {
+const restore = [process.stdout, process.stderr].map((stream) => {
   const write = stream.write.bind(stream)
   stream.write = ((chunk: unknown, ...args: unknown[]) => {
     logs.push(String(chunk))
     return write(chunk as never, ...(args as never[]))
   }) as typeof stream.write
-}
+  return () => {
+    stream.write = write
+  }
+})
 
 await setup({
-  rootDir: resolve('../fixtures/basic'),
+  rootDir: resolve('../fixtures/static-lang'),
 })
+
+// setup() builds inside a beforeAll hook, so keep the streams patched until the suite ends
+afterAll(() => restore.forEach(reset => reset()))
 
 describe('validateAppHead with i18n installed but unconfigured', () => {
   it('flags a static lang as a locale mismatch, not an i18n conflict', () => {

--- a/test/e2e/validateAppHeadStaticLang.test.ts
+++ b/test/e2e/validateAppHeadStaticLang.test.ts
@@ -1,0 +1,24 @@
+import { createResolver } from '@nuxt/kit'
+import { setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+const logs: string[] = []
+for (const stream of [process.stdout, process.stderr]) {
+  const write = stream.write.bind(stream)
+  stream.write = ((chunk: unknown, ...args: unknown[]) => {
+    logs.push(String(chunk))
+    return write(chunk as never, ...(args as never[]))
+  }) as typeof stream.write
+}
+
+await setup({
+  rootDir: resolve('../fixtures/basic'),
+})
+
+describe('validateAppHead with i18n installed but unconfigured', () => {
+  it('flags a static lang as a locale mismatch, not an i18n conflict', () => {
+    expect(logs.join('\n')).toContain(`defaultLocale: 'fr'`)
+  })
+})

--- a/test/fixtures/basic/.nuxtrc
+++ b/test/fixtures/basic/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.0.3"
+setups.@nuxt/test-utils="4.1.0"

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -12,13 +12,5 @@ export default defineNuxtConfig({
     },
   },
 
-  app: {
-    head: {
-      htmlAttrs: {
-        lang: 'fr',
-      },
-    },
-  },
-
   compatibilityDate: '2024-08-07',
 })

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -12,5 +12,13 @@ export default defineNuxtConfig({
     },
   },
 
+  app: {
+    head: {
+      htmlAttrs: {
+        lang: 'fr',
+      },
+    },
+  },
+
   compatibilityDate: '2024-08-07',
 })

--- a/test/fixtures/static-lang/nuxt.config.ts
+++ b/test/fixtures/static-lang/nuxt.config.ts
@@ -1,0 +1,19 @@
+import NuxtSeoUtils from '../../../src/module'
+
+export default defineNuxtConfig({
+  modules: [NuxtSeoUtils],
+
+  site: {
+    url: 'https://example.com',
+    name: 'Test Static Lang',
+  },
+
+  // a non-english lang with no matching `site.defaultLocale`, the case validateAppHead exists for
+  app: {
+    head: {
+      htmlAttrs: {
+        lang: 'fr',
+      },
+    },
+  },
+})

--- a/test/fixtures/static-lang/pages/index.vue
+++ b/test/fixtures/static-lang/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Test Static Lang</h1>
+  </div>
+</template>


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

A user sets `app.head.htmlAttrs.lang: 'fr'` and never touches `site.defaultLocale`, so `og:locale`, canonical casing and Schema.org all keep saying `en`. Nothing tells them. The html lang looks right in the page source, which is the part that makes it hard to spot.

Unhead's own rules already cover the tags themselves. Its Vite plugin injects the runtime `ValidatePlugin` on the client, and `app.head` reaches the resolved head through Nuxt's `useHead`, so typos, zoom-blocking viewports and robots conflicts are already reported in the console. This only checks what Unhead cannot see: how the Nuxt config head lines up with site config, i18n, and the per route tags this module owns.

```
[nuxt-seo-utils]  WARN  Found 3 issues in your Nuxt config head.
  · og:type repeats a default. nuxt-seo-utils sets it by default. You can remove it.
  ✖ og:site_name is "Stale Name" but site name is "Real Name". Keep one source of truth. Set site.name and remove the meta tag.
  ✖ link[rel="canonical"] is set in app.head. It points every page at one URL. nuxt-seo-utils sets a canonical per route.
```

Reads the raw layer config rather than the resolved head, since Nuxt injects its own `charset` and `viewport` into `app.head.meta` and those would otherwise read as user input. Opt out with `seo: { validateAppHead: false }`.

Two things I left alone and would take a second opinion on:

- Dead tags (`keywords`, `X-UA-Compatible`, `revisit-after`) are not flagged here. That felt like it belongs in Unhead's rule set rather than this module, but it is the sort of thing people expect an SEO module to tell them.
- Separately, `hasNuxtModule('@nuxtjs/i18n')` is true in `test/fixtures/basic` even though nothing there configures i18n. Our optional `moduleDependencies` entry seems to pull it in whenever it is merely resolvable, which also decides whether we register `defaultsWaitI18n` over `defaults`. Not touched in this PR.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).