### PR TITLE
feat: allow disabling automatic Twitter tags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ export default defineNuxtConfig({
     enabled: true,
     metaDataFiles: true,
     automaticOgAndTwitterTags: true,
+    automaticTwitterTags: true,
     fallbackTitle: true,
     canonicalQueryWhitelist: [],
     redirectToCanonicalSiteUrl: true,

--- a/docs/content/3.api/0.config.md
+++ b/docs/content/3.api/0.config.md
@@ -81,6 +81,14 @@ For example:
 - If you supply a title, this will automatically add an og:title.
 - If you provide an og:image, it will automatically add a twitter:image.
 
+## `automaticTwitterTags: boolean`{lang="ts"}
+
+- Default: `true`{lang="ts"}
+
+Whether to infer Twitter metadata from Open Graph metadata.
+
+Set this to `false` to keep Open Graph inference without adding `twitter:card`.
+
 ## `tagPriority: number | 'critical' | 'high' | 'low' | \`before:\${string}\` | \`after:\${string}\``{lang="ts"}
 
 - Default: `'low'`{lang="ts"}

--- a/src/module.ts
+++ b/src/module.ts
@@ -56,6 +56,12 @@ export interface ModuleOptions {
    */
   automaticOgAndTwitterTags: boolean
   /**
+   * Whether to infer Twitter metadata from Open Graph metadata.
+   *
+   * @default true
+   */
+  automaticTwitterTags: boolean
+  /**
    * Attempts to treeshake the `useSeoMeta` function. Can save around 5kb in the client bundle.
    *
    * @default true
@@ -210,6 +216,7 @@ export default defineNuxtModule<ModuleOptions>({
     extendNuxtConfigAppHeadTypes: true,
     setupNuxtConfigAppHeadWithMoreDefaults: true,
     automaticOgAndTwitterTags: true,
+    automaticTwitterTags: true,
     canonicalLowercase: true,
     validateAppHead: true,
     tagPriority: 'low',
@@ -353,6 +360,7 @@ export default defineNuxtModule<ModuleOptions>({
         'tag',
       ],
       canonicalLowercase: config.canonicalLowercase,
+      automaticTwitterTags: config.automaticTwitterTags,
       tagPriority: config.tagPriority,
       separator: headTemplateParams?.separator,
       titleSeparator: headTemplateParams?.titleSeparator,

--- a/src/runtime/app/plugins/inferSeoMetaPlugin.ts
+++ b/src/runtime/app/plugins/inferSeoMetaPlugin.ts
@@ -2,6 +2,12 @@ import { injectHead } from '@unhead/vue'
 import { InferSeoMetaPlugin, TemplateParamsPlugin } from '@unhead/vue/plugins'
 import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
 
+// unhead v3 skips the twitter:card push for `twitterCard: false`, but v2 ignores
+// the option and falls back to `summary_large_image`. Both majors render the option
+// value verbatim, so we push a sentinel card and strip it before resolve. The strip
+// only matches the sentinel, user-set twitter:card tags always survive.
+const disabledTwitterCard = 'x-nuxt-seo-utils-disabled-twitter-card'
+
 export default defineNuxtPlugin(() => {
   const head = injectHead()
 
@@ -12,7 +18,24 @@ export default defineNuxtPlugin(() => {
   const { automaticTwitterTags } = useRuntimeConfig().public['seo-utils'] as { automaticTwitterTags?: boolean }
 
   head.use(TemplateParamsPlugin)
-  head.use(InferSeoMetaPlugin({
-    twitterCard: automaticTwitterTags === false ? false : undefined,
-  }))
+
+  if (automaticTwitterTags === false) {
+    // the option is typed as a card preset, but every major renders the value verbatim
+    head.use(InferSeoMetaPlugin({ twitterCard: disabledTwitterCard as 'summary_large_image' }))
+    head.use({
+      key: 'nuxt-seo-utils:twitter-card-suppression',
+      hooks: {
+        'tags:beforeResolve': ({ tags }) => {
+          for (let i = tags.length - 1; i >= 0; i--) {
+            const tag = tags[i]!
+            if (tag.tag === 'meta' && tag.props.name === 'twitter:card' && tag.props.content === disabledTwitterCard)
+              tags.splice(i, 1)
+          }
+        },
+      },
+    })
+  }
+  else {
+    head.use(InferSeoMetaPlugin())
+  }
 })

--- a/src/runtime/app/plugins/inferSeoMetaPlugin.ts
+++ b/src/runtime/app/plugins/inferSeoMetaPlugin.ts
@@ -1,6 +1,6 @@
 import { injectHead } from '@unhead/vue'
 import { InferSeoMetaPlugin, TemplateParamsPlugin } from '@unhead/vue/plugins'
-import { defineNuxtPlugin } from 'nuxt/app'
+import { defineNuxtPlugin, useRuntimeConfig } from 'nuxt/app'
 
 export default defineNuxtPlugin(() => {
   const head = injectHead()
@@ -9,6 +9,10 @@ export default defineNuxtPlugin(() => {
   if (!head)
     return
 
+  const { automaticTwitterTags } = useRuntimeConfig().public['seo-utils'] as { automaticTwitterTags?: boolean }
+
   head.use(TemplateParamsPlugin)
-  head.use(InferSeoMetaPlugin())
+  head.use(InferSeoMetaPlugin({
+    twitterCard: automaticTwitterTags === false ? false : undefined,
+  }))
 })

--- a/test/compat-v2/app.vue
+++ b/test/compat-v2/app.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 // exercises the cross-major head paths on the unhead v2 stack:
-// - useSeoMeta input feeds the InferSeoMetaPlugin (og:* / twitter:* inference)
+// - useSeoMeta input feeds the InferSeoMetaPlugin (og:* inference, twitter
+//   card suppressed via automaticTwitterTags: false in nuxt.config.ts)
 // - the module's default titleTemplate ('%s %separator %siteName') resolves via
 //   the TemplateParamsPlugin against the site-config templateParams
 useSeoMeta({

--- a/test/compat-v2/nuxt.config.ts
+++ b/test/compat-v2/nuxt.config.ts
@@ -1,6 +1,10 @@
 export default defineNuxtConfig({
   modules: ['nuxt-seo-utils'],
 
+  seo: {
+    automaticTwitterTags: false,
+  },
+
   site: {
     url: 'https://example.com',
     name: 'Compat v2',

--- a/test/compat-v2/render.test.ts
+++ b/test/compat-v2/render.test.ts
@@ -15,7 +15,7 @@ await setup({
 })
 
 describe('unhead v2 compatibility', () => {
-  it('renders inferred og/twitter tags and resolved template params', async () => {
+  it('renders inferred og tags, suppresses twitter:card, and resolves template params', async () => {
     const html = await $fetch('/') as string
     const $ = load(html)
 
@@ -24,8 +24,9 @@ describe('unhead v2 compatibility', () => {
     // InferSeoMetaPlugin: og:title / og:description inferred from useSeoMeta
     expect(meta('property="og:title"')).toContain('Hello v2')
     expect(meta('property="og:description"')).toBe('inferred description on the unhead v2 stack')
-    // InferSeoMetaPlugin: twitter card is synthesised
-    expect(meta('name="twitter:card"')).toBe('summary_large_image')
+    // automaticTwitterTags: false must not synthesise a twitter:card (unhead v2
+    // ignores the `twitterCard: false` option, so the module strips its own card)
+    expect(meta('name="twitter:card"')).toBeUndefined()
 
     // TemplateParamsPlugin: the module's '%s %separator %siteName' titleTemplate
     // resolves %siteName from the site config templateParams

--- a/test/e2e/automaticTwitterTags.test.ts
+++ b/test/e2e/automaticTwitterTags.test.ts
@@ -1,0 +1,39 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { load } from 'cheerio'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../fixtures/basic'),
+  nuxtConfig: {
+    modules: [
+      resolve('../../src/module'),
+    ],
+    // @ts-expect-error module config key
+    seo: {
+      automaticTwitterTags: false,
+      treeShakeUseSeoMeta: false,
+    },
+    app: {
+      head: {
+        title: 'Open Graph only',
+        meta: [
+          { name: 'description', content: 'Open Graph description' },
+        ],
+      },
+    },
+  },
+})
+
+describe('automatic Twitter tags', () => {
+  it('keeps Open Graph inference when Twitter tags are disabled', async () => {
+    const html = await $fetch<string>('/')
+    const $ = load(html)
+
+    expect($('meta[property="og:title"]').attr('content')).toContain('Open Graph only')
+    expect($('meta[property="og:description"]').attr('content')).toBe('Open Graph description')
+    expect($('meta[name="twitter:card"]')).toHaveLength(0)
+  }, 30_000)
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Resolves #140

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Unhead 3.3 warns about the inferred `twitter:card`, but disabling `automaticOgAndTwitterTags` also removes Open Graph inference. `automaticTwitterTags: false` now suppresses the card while keeping `og:title` and `og:description` inference.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).